### PR TITLE
Support added for multi sql connections

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -4,7 +4,10 @@ import fs from 'fs-extra';
 class Sql {
     async setConfig(config) {
         if (config) {
-            this.pool = await mssql.connect(config);
+            // Used the ConnectionPool class directly because internally if one pool is already connected mssql returns that instead of giving the 2nd new connection. 
+            let poolObj = new mssql.ConnectionPool(config);
+            poolObj = await poolObj.connect();
+            this.pool = poolObj;
         } else if (this.pool) {
             this.pool = null;
         }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -4,10 +4,7 @@ import fs from 'fs-extra';
 class Sql {
     async setConfig(config) {
         if (config) {
-            // Used the ConnectionPool class directly because internally if one pool is already connected mssql returns that instead of giving the 2nd new connection. 
-            let poolObj = new mssql.ConnectionPool(config);
-            poolObj = await poolObj.connect();
-            this.pool = poolObj;
+            this.pool = await new mssql.ConnectionPool(config).connect();
         } else if (this.pool) {
             this.pool = null;
         }


### PR DESCRIPTION
The connect function if the mssql plugin was returning the same pool again if already connected, so used the ConnectionPool class directly.