### PR TITLE
Added Support to force Case Sensitive for MySQL

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -53,21 +53,12 @@ class Mysql extends Sql {
 
     insertedIdStatement = "SELECT LAST_INSERT_ID() AS Id;";
 
-    setConfig({
-        logger,
-        timeoutLogLevel = "info",
-        queryLogThreshold = 1000,
-        ...config
-    } = {}) {
-        if (logger) {
-            this.logger = logger;
+    async createPoolConnection(config) {
+        if(config) {
+            return await new mysql.createPool(config);
         }
-        this.queryLogThreshold = queryLogThreshold;
-        this.timeoutLogLevel = timeoutLogLevel;
-        if (config) {
-            this.pool = mysql.createPool(config);
-        } else if (this.pool) {
-            this.pool = null;
+        else {
+            return null;
         }
     }
 

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -32,16 +32,16 @@ class Sql {
     };
 
     parameterPrefix = "@";
-    forceCaseSensitive = false;
+    forceCaseInsensitive = false;
     insertedIdStatement = "SELECT SCOPE_IDENTITY() AS Id;";
 
-    async setConfig({ logger, timeoutLogLevel = "info", queryLogThreshold = 1000, forceCaseSensitive, ...config } = {}) {
+    async setConfig({ logger, timeoutLogLevel = "info", queryLogThreshold = 1000, forceCaseInsensitive, ...config } = {}) {
         if (logger) {
             this.logger = logger;
         }
         this.queryLogThreshold = queryLogThreshold;
         this.timeoutLogLevel = timeoutLogLevel;
-        this.forceCaseSensitive = forceCaseSensitive;
+        this.forceCaseInsensitive = forceCaseInsensitive;
         this.pool = await this.createPoolConnection(config);
     }
 
@@ -364,7 +364,7 @@ class Sql {
         if (!parameters) {
             return query;
         }
-        const { buildParameterName, dataTypes, forceCaseSensitive } = this;
+        const { buildParameterName, dataTypes, forceCaseInsensitive } = this;
         const paramNames = Object.keys(parameters);
         const whereClauses = [];
         for (let index = 0, len = paramNames.length; index < len; index++) {
@@ -394,7 +394,7 @@ class Sql {
                 continue;
             }
 
-            if(forceCaseSensitive) {
+            if(forceCaseInsensitive) {
                 if(typeof value === 'string' || sqlType === dataTypes.string) {
                     value = value.toUpperCase();
                 }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -32,21 +32,27 @@ class Sql {
     };
 
     parameterPrefix = "@";
-
+    forceCaseSensitive = false;
     insertedIdStatement = "SELECT SCOPE_IDENTITY() AS Id;";
 
-    async setConfig({ logger, timeoutLogLevel = "info", queryLogThreshold = 1000, ...config } = {}) {
+    async setConfig({ logger, timeoutLogLevel = "info", queryLogThreshold = 1000, forceCaseSensitive, ...config } = {}) {
         if (logger) {
             this.logger = logger;
         }
         this.queryLogThreshold = queryLogThreshold;
         this.timeoutLogLevel = timeoutLogLevel;
-        if (config) {
-            this.pool = await new mssql.ConnectionPool(config).connect();
-        } else if (this.pool) {
-            this.pool = null;
-        }
+        this.forceCaseSensitive = forceCaseSensitive;
+        this.pool = await this.createPoolConnection(config);
     }
+
+    async createPoolConnection(config) {
+        if(config) {
+            return await new mssql.ConnectionPool(config).connect();
+        }
+        else {
+            return null;
+        }
+	}
 
     allowTvp = true;
 
@@ -358,7 +364,7 @@ class Sql {
         if (!parameters) {
             return query;
         }
-        const { buildParameterName, dataTypes } = this;
+        const { buildParameterName, dataTypes, forceCaseSensitive } = this;
         const paramNames = Object.keys(parameters);
         const whereClauses = [];
         for (let index = 0, len = paramNames.length; index < len; index++) {
@@ -388,6 +394,16 @@ class Sql {
                 continue;
             }
 
+            if(forceCaseSensitive) {
+                if(typeof value === 'string' || sqlType === dataTypes.string) {
+                    value = value.toUpperCase();
+                }
+                if(Array.isArray(value)) {
+                    value = value.map(val => typeof val === 'string' ? val.toUpperCase() : val);
+                }
+                fieldName = `UPPER(${fieldName})`;
+            }
+
             if (paramName.indexOf('.') > -1) {
                 const parts = paramName.split('.');
                 paramName = parts[parts.length - 1];
@@ -403,7 +419,7 @@ class Sql {
                 statement = inResult.statement;
                 if (query && !isBetweenOperator) {
                     // ability to replace @{FieldName} if we have embedded parameter in inner query
-                    query = query.replace(`${this.parameterPrefix}{${fieldName}}`, inResult.paramNames.join(', '));
+                    query = query.replace(`${this.parameterPrefix}{${paramName}}`, inResult.paramNames.join(', '));
                 }
             } else {
                 if (sqlType !== undefined && sqlType !== null) {


### PR DESCRIPTION
This pull request includes several changes to the `Mysql` and `Sql` classes to improve the configuration and query handling. The key changes include adding a new configuration option for case sensitivity, refactoring the pool connection creation method, and updating query parameter handling to respect the case sensitivity setting.

Improvements and refactoring:

* [`lib/mysql.js`](diffhunk://#diff-de998d404b79c0da12e1ef964ca5dcba3c14ce73ad232c5e3ce314824e1c1e5aL56-R61): Refactored the `setConfig` method to `createPoolConnection` to handle pool connection creation and return the pool instance.

Configuration enhancements:

* [`lib/sql.js`](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baL35-R53): Added a new configuration option `forceCaseSensitive` to the `setConfig` method to enable case-sensitive query handling.

Query handling updates:

* [`lib/sql.js`](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baL35-R53): Updated the `setConfig` method to utilize the `createPoolConnection` method for setting up the connection pool.
* [`lib/sql.js`](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baL361-R367): Modified the query parameter handling to respect the `forceCaseSensitive` setting, converting string values and field names to uppercase when enabled. [[1]](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baL361-R367) [[2]](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baR397-R406) [[3]](diffhunk://#diff-955d6ecf7d61593434abcd2aaf3b73ad63d21eb25ebe2dc9fec1021a596db3baL406-R422)