### PR TITLE
Uses replaceAll for parameter substitution in queries

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -438,7 +438,7 @@ class Sql {
                 statement = inResult.statement;
                 if (query && !isBetweenOperator) {
                     // ability to replace @{FieldName} if we have embedded parameter in inner query
-                    query = query.replace(`${this.parameterPrefix}{${paramName}}`, inResult.paramNames.join(', '));
+                    query = query.replaceAll(`${this.parameterPrefix}{${paramName}}`, inResult.paramNames.join(', '));
                 }
             } else {
                 if (sqlType !== undefined && sqlType !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Ensures all occurrences of parameter placeholders are replaced in query strings, improving reliability for embedded parameters in inner queries. Bumps version to 1.0.38.