### PR TITLE
Adds slow-request logger and HTTP/2 transport

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -32,7 +32,7 @@ const fileStreamConfig = {
     max_logs: '10d',
     date_format: 'YYYY-MM-DD',
     size: '1m',
-    extension: ".log",
+    extension: ".json",
     ...fileConfig
 };
 

--- a/lib/middleware/slow-request-logger.mjs
+++ b/lib/middleware/slow-request-logger.mjs
@@ -1,0 +1,23 @@
+const slowRequestLogger = ({ threshold = 1000 } = {}) => {
+    return (req, res, next) => {
+        const start = process.hrtime.bigint();
+        const logDuration = (eventName) => {
+            const durMs = Number(process.hrtime.bigint() - start) / 1e6;
+            if (durMs < threshold) return;
+            const logger = req.log || console;
+            logger.error({
+                durMs: Math.round(durMs),
+                statusCode: res.statusCode,
+                url: req.originalUrl || req.url,
+                method: req.method
+            }, 'slow request');
+        };
+
+        res.on('finish', () => logDuration('finish'));
+        res.on('close', () => logDuration('close'));
+
+        next();
+    }
+};
+
+export default slowRequestLogger;

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -1,71 +1,121 @@
 import build from "pino-abstract-transport";
-import os from 'os';
-// Function to find the value of a specific header
-function getHeaderValue(headersArray = [], headerName) {
-    const index = headersArray.indexOf(headerName);
-    if (index !== -1 && index < headersArray.length - 1) {
-        return headersArray[index + 1];
-    }
-    return null; // Header not found
-}
+import os from "os";
+import http2 from "node:http2";
 
+// Constants computed once
+const MACHINE_NAME = os.hostname();
+const CWD = process.cwd();
+const H2_SESSION_CLOSE_TIMEOUT_MS = 300;
+
+// Convert nested objects into URLSearchParams-friendly strings
 const convertToURLSearchParams = (obj) => {
-    const params = new URLSearchParams();
-
-    Object.entries(obj).forEach(([key, value]) => {
-        typeof value === 'object' && value !== null
-            ? params.append(key, JSON.stringify(value))
-            : params.append(key, value);
-    });
-
-    return params.toString();
+  const params = new URLSearchParams();
+  Object.entries(obj || {}).forEach(([key, value]) => {
+    typeof value === "object" && value !== null
+      ? params.append(key, JSON.stringify(value))
+      : params.append(key, value ?? "");
+  });
+  return params.toString();
 };
 
-const createWriteStream = async function (options) {
-    /**
-     * @type {Array<Promise>} Send tasks.
-     */
-    const tasks = [];
+/**
+ * Creates a write stream for pino transport that POSTs each log line.
+ * Options:
+ * - url: string (required) Target endpoint
+ * - http2: boolean (optional) If true and endpoint is https, use HTTP/2 client
+ * - method: string (optional) HTTP method; defaults to "POST"
+ */
+const createWriteStream = function (options = {}) {
+  const baseURL = new URL(options.url);
+  const useHttp2 = options.http2 === true && baseURL.protocol === "https:";
+  const method = (options.method || "POST").toUpperCase();
 
-    return build(
-        async (source) => {
-            // We use an async iterator to read log lines.
-            for await (let line of source) {
-                const { req = {}, rawUrl } = JSON.parse(line);
-                const params = { ...req.params, ...req.body };
-                const formParams = new URLSearchParams({
-                    SystemPath: process.cwd(),
-                    RemoteHost: req.remoteAddress || "",
-                    Form: convertToURLSearchParams(params),
-                    QueryString: convertToURLSearchParams(req.query || {}),
-                    UserAgent: req.headers ? req.headers["user-agent"] : getHeaderValue(req?.rawHeaders, "User-Agent") || "",
-                    RawUrl: rawUrl ?? (req.url || ""),
-                    User: req.Username || "",
-                    AbsoluteUrl: `${req.serverUrl ?? ""}${req.url ?? ""}`,
-                });
-                const headers = {
-                    MachineName: os.hostname(),
-                    SystemPath: process.env.PATH
-                };
-                const task = fetch(options.url + `?${formParams.toString()}`, {
-                    method: 'POST', // Specify the POST method
-                    headers,
-                    body: line
-                });
-                tasks.push(task);
-            }
-            return source;
-        },
-        {
-            parse: "lines",
-            async close() {
-                // Wait for all send tasks to complete.
-                await Promise.all(tasks);
-            },
+  // Prepare HTTP/2 session if enabled (synchronously creates a client session)
+  let h2Session = null;
+  if (useHttp2) {
+    h2Session = http2.connect(`${baseURL.protocol}//${baseURL.host}`);
+    h2Session.on("error", () => {});
+  }
+
+  return build(
+    async (source) => {
+      for await (const line of source) {
+        let log;
+        try {
+          log = JSON.parse(line);
+        } catch {
+          // Skip lines that aren't valid JSON
+          continue;
         }
-    );
+
+        const { req = {}, ...others } = log;
+        const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...errorInfo } = others;
+        const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
+
+        // Build query params per line
+        const queryParams = new URLSearchParams();
+        queryParams.set("Machine Name", hostname || MACHINE_NAME);
+        queryParams.set("System Path", CWD);
+        queryParams.set("Remote Host", req.remoteAddress || "");
+        queryParams.set("User Agent", req.userAgent || "");
+        queryParams.set("Absolute Url", req.url || "");
+        queryParams.set("UrlReferrer", req.referrer || "");
+        queryParams.set("Date/ Time (UTC)", time);
+        queryParams.set("User", Username);
+        queryParams.set("exception", JSON.stringify(errorInfo));
+        queryParams.set("Form", convertToURLSearchParams(paramsObj));
+        queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
+
+        if (h2Session && !h2Session.closed && !h2Session.destroyed) {
+          // HTTP/2: header names must be lowercase; :method and :path are pseudo-headers
+          const headers = {
+            ":method": method,
+            ":path": `${baseURL.pathname}${baseURL.search}`,
+            "content-type": "application/x-www-form-urlencoded"
+          };
+
+          await new Promise((resolve, reject) => {
+            const stream = h2Session.request(headers);
+            // Consume response to free stream resources
+            stream.on("response", () => {});
+            stream.on("data", () => {});
+            stream.on("end", resolve);
+            stream.on("error", reject);
+            stream.end(queryParams.toString());
+          });
+        } else {
+          // Fallback to fetch (HTTP/1.1). Undici provides keep-alive by default.
+          const headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+          };
+          await fetch(baseURL.toString(), {
+            method,
+            headers,
+            body: queryParams.toString(),
+          });
+        }
+      }
+
+      return source;
+    },
+    {
+      parse: "lines",
+      async close() {
+        if (h2Session) {
+          await new Promise((resolve) => {
+            try {
+              h2Session.close();
+              h2Session.once("close", resolve);
+              setTimeout(resolve, H2_SESSION_CLOSE_TIMEOUT_MS);
+            } catch {
+              resolve();
+            }
+          });
+        }
+      },
+    }
+  );
 };
 
 export default createWriteStream;
-
 export { createWriteStream };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "main": "index.js",
   "license": "MIT",
   "type": "module",
@@ -20,6 +20,7 @@
     "./business/auth": "./lib/business/auth.mjs",
     "./business/business-objects": "./lib/business/business-objects.mjs",
     "./middleware/response-transformer": "./lib/middleware/response-transformer.mjs",
+    "./middleware/slow-request-logger": "./lib/middleware/slow-request-logger.mjs",
     "./business/elastic-business-base": "./lib/business/elastic-business-base.mjs",
     "./azure": "./lib/azure.js",
     "./elastic": "./lib/elastic.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,17 +238,17 @@
   resolved "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz"
   integrity sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==
 
+"@ldapjs/asn1@2.0.0", "@ldapjs/asn1@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-2.0.0.tgz"
+  integrity sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA==
+
 "@ldapjs/asn1@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-1.2.0.tgz"
   integrity sha512-KX/qQJ2xxzvO2/WOvr1UdQ+8P5dVvuOLk/C9b1bIkXxZss8BaR28njXdPgFCpj5aHaf1t8PmuVnea+N9YG9YMw==
 
-"@ldapjs/asn1@^2.0.0", "@ldapjs/asn1@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@ldapjs/asn1/-/asn1-2.0.0.tgz"
-  integrity sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA==
-
-"@ldapjs/attribute@^1.0.0", "@ldapjs/attribute@1.0.0":
+"@ldapjs/attribute@1.0.0", "@ldapjs/attribute@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@ldapjs/attribute/-/attribute-1.0.0.tgz"
   integrity sha512-ptMl2d/5xJ0q+RgmnqOi3Zgwk/TMJYG7dYMC0Keko+yZU6n+oFM59MjQOUht5pxJeS4FWrImhu/LebX24vJNRQ==
@@ -438,6 +438,11 @@ async-csv@^2.1.3:
   dependencies:
     csv "^5.1.3"
 
+async@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.3.tgz"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
+
 async@^2.6.4:
   version "2.6.4"
   resolved "https://registry.npmjs.org/async/-/async-2.6.4.tgz"
@@ -449,11 +454,6 @@ async@^3.2.4:
   version "3.2.6"
   resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
-
-async@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.3.tgz"
-  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -652,7 +652,7 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-core-util-is@~1.0.0, core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
@@ -710,7 +710,7 @@ dayjs@^1.11.13, dayjs@^1.8.34:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@^4.3.3, debug@^4.3.4, debug@4:
+debug@4, debug@^4.3.3, debug@^4.3.4:
   version "4.4.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -1100,7 +1100,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1696,33 +1696,7 @@ read@1.0.x:
   dependencies:
     mute-stream "~0.0.4"
 
-readable-stream@^2.0.0:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.2:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.5:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -1754,19 +1728,6 @@ readable-stream@^4.2.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
-
-readable-stream@~2.3.6:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
 
 readdir-glob@^1.1.2:
   version "1.1.3"
@@ -1851,7 +1812,7 @@ secure-json-parse@^2.4.0:
   resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
-semver@^7.3.8, semver@^7.5.4:
+semver@^7.5.4:
   version "7.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -2064,19 +2025,19 @@ vasync@^2.2.1:
   dependencies:
     verror "1.10.0"
 
-verror@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz"
-  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+verror@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz"
+  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
   dependencies:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"


### PR DESCRIPTION
Adds a middleware to log requests that exceed a configurable duration threshold to help surface performance regressions.

Reworks the HTTP transport used for sending structured logs to POST line-by-line data to a remote endpoint with optional HTTP/2 support (uses a persistent H2 session for HTTPS targets and falls back to fetch). Improves payload handling by serializing nested objects, URL-encoding form data, skipping invalid JSON lines, and ensuring sessions are closed cleanly.

Switches file log extension to .json to keep logs structured. Updates module exports and bumps package version; lockfile refined to reflect dependency resolution changes.