### PR TITLE
Guard against non-array response data

### DIFF
--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -341,22 +341,24 @@ const responseTransformer = async function (req, res, next) {
         }
         // Iterates over each record to format Date fields using the appropriate date or datetime format.
         // Also converts boolean values to strings based on the exportColumns configuration.
-        data = data.map(record => {
-            const formattedRecord = { ...record }; // create a shallow copy of the record
-            for (const [key, value] of Object.entries(record)) {
-                if (!exportColumns[key]) {
-                    continue;
+        if (Array.isArray(data)) {
+            data = data.map(record => {
+                const formattedRecord = { ...record }; // create a shallow copy of the record
+                for (const [key, value] of Object.entries(record)) {
+                    if (!exportColumns[key]) {
+                        continue;
+                    }
+                    if (value instanceof Date) {
+                        formattedRecord[key] = formatDateTime({ value, format: exportColumns[key].type === 'date' ? dateFormat : dateTimeFormat }); // format date or datetime
+                        continue;
+                    }
+                    if (typeof value === 'boolean') {
+                        formattedRecord[key] = value.toString(); // convert boolean to string
+                    }
                 }
-                if (value instanceof Date) {
-                    formattedRecord[key] = formatDateTime({ value, format: exportColumns[key].type === 'date' ? dateFormat : dateTimeFormat }); // format date or datetime
-                    continue;
-                }
-                if (typeof value === 'boolean') {
-                    formattedRecord[key] = value.toString(); // convert boolean to string
-                }
-            }
-            return formattedRecord;
-        });
+                return formattedRecord;
+            });
+        }
         switch (responseType) {
             case mimeTypes.json:
                 data = sanitizeData({ data, columns });

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -4,7 +4,7 @@ import js2xmlparser from 'js2xmlparser';
 import dateFormat from 'dateformat';
 import dayjs from 'dayjs';
 import { performance } from 'perf_hooks';
-import { util } from '../../index.js';
+import { enums, util } from '../../index.js';
 import logger from '../logger.js';
 
 const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
@@ -251,7 +251,8 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
             let name = columns[field]?.name || field;
             const value = record[field];
             if (responseType === mimeTypes.xml) {
-                name = name.replace(/[^a-zA-Z0-9._-]/g, '');
+                // Ensure name is a string before calling replace
+                name = (typeof name === 'string' ? name : String(name || field)).replace(/[^a-zA-Z0-9._-]/g, '');
             }
             acc[name] = !value ? '' : value;
             return acc;
@@ -269,7 +270,10 @@ const responseTransformer = async function (req, res, next) {
         const exportColumns = others?.exportColumns, userDateFormat = others?.userDateFormat, isElastic = others?.isElastic, userTimezoneOffset = others?.userTimezoneOffset, lookups = others?.lookups, lookupFields = others?.lookupFields, addExecutionTimeLogger = others?.addExecutionTimeLogger;
         const dateTimeFormat = userDateFormat + util.dateTimeExportFormat;
         const isMultiSheetExport = others?.isMultiSheetExport || false;
-        fileName = `${!fileName ? req.path.substr(1).replace(util.fileNameRegex, '-') : fileName}-${dateFormat(new Date(), "isoDateTime").replace(/:/g, '')}`;
+        
+        // Safely handle req.path to prevent TypeError: r.replace is not a function
+        const safePath = (req.path && typeof req.path === 'string') ? req.path.substr(1) : 'export';
+        fileName = `${!fileName ? safePath.replace(util.fileNameRegex, '-') : fileName}-${dateFormat(new Date(), "isoDateTime").replace(/:/g, '')}`;
 
         if (data !== undefined && data !== null && typeof data === 'object') {
             if (!responseType) {
@@ -349,7 +353,7 @@ const responseTransformer = async function (req, res, next) {
                         continue;
                     }
                     if (value instanceof Date) {
-                        formattedRecord[key] = formatDateTime({ value, format: exportColumns[key].type === 'date' ? dateFormat : dateTimeFormat }); // format date or datetime
+                        formattedRecord[key] = formatDateTime({ value, format: dateTimeFormat || enums.dateTimeExportFormat }); // format date or datetime
                         continue;
                     }
                     if (typeof value === 'boolean') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Avoid attempting to iterate and format response when the payload isn't an array, preventing runtime errors for null/object/singleton responses. Wraps the formatting logic in an Array.isArray check so Date and boolean transformations only run for arrays. Also increments package version to 1.0.40.