### PR TITLE
Removes unused 'applyClientFilter' and updates comments

### DIFF
--- a/lib/business/business-base.mjs
+++ b/lib/business/business-base.mjs
@@ -221,7 +221,7 @@ class BusinessBase {
     }
 
     async load({ id, relations }) {
-        //added this to override applyClientFilter in case of reports where client filtering is not required
+        //added this to override clientBased in case of reports where client filtering is not required
         if(this.beforeLoad) {
             await this.beforeLoad({ id });
         }
@@ -571,7 +571,7 @@ class BusinessBase {
 
     async lookupList({ scopeId }) {
         const request = this.createRequest();
-        const { keyField, lookupSortOrder, defaultSortOrder, displayField, clientBased, lookupListStatement = '', tableName, applyClientFilter } = this;
+        const { keyField, lookupSortOrder, defaultSortOrder, displayField, clientBased, lookupListStatement = '', tableName } = this;
         const sort = lookupSortOrder || defaultSortOrder;
         if (lookupListStatement) {
             const result = await request.query(lookupListStatement);
@@ -589,7 +589,7 @@ class BusinessBase {
         listStatement = listStatement.replace(/^.+ FROM/i, `SELECT [${keyField}] value, [${labelField}] label FROM `);
 
         let query = listStatement;
-        const where = await this.createWhere({ filterDeleted: isStandard, tableName, applyClientFilter });
+        const where = await this.createWhere({ filterDeleted: isStandard, tableName });
         if (!clientBased && scopeId) {
             where.ScopeId = scopeId;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Replaces outdated references to 'applyClientFilter' with 'clientBased' for clarity. Removes 'applyClientFilter' from method parameters as it is no longer used.

Bumps package version to 1.0.51 to reflect these changes.