### PR TITLE
Task #70411 - MICC France | Daily summary of alerts split by Outlet, not alert

### DIFF
--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -27,10 +27,10 @@ const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
  * @param {string} [tableRowHeaderStyle='background-color: #4a5568; color: white;'] - CSS style string applied to table row headers. Default is dark gray background with white text.
  * @param {boolean} [showTableBorder=true] - Whether to show table borders. Default is true.
  * @param {string} [groupByKey=null] - Column key to group rows by for rowspan (e.g., 'OutletCode'). When set, rows with same value will be grouped and outlet info will span multiple alert rows.
- * @param {Array} [outletColumns=null] - Array of column dataKeys that should use rowspan when grouping.
+ * @param {Array} [groupColumns=null] - Array of column dataKeys that should use rowspan when grouping.
  * @returns {string} HTML table as a string.
  */
-const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, outletColumns = null) => {
+const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, groupColumns = null) => {
     if (!rows) {
         return '';
     }
@@ -86,7 +86,7 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
     tableRows.push(`<thead><tr style='${tableRowHeaderStyle}'><th>` + row.join("</th><th>") + "</th></tr></thead>");
 
     // Handle grouping with rowspan
-    if (groupByKey && outletColumns) {
+    if (groupByKey && groupColumns) {
         const grouped = {};
         const groupOrder = [];
         
@@ -110,14 +110,14 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
                 for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
                     let v = item[dataKey];
                     colClass = '';
-                    const shouldUseRowspan = outletColumns.includes(dataKey) && itemIndex === 0;
+                    const shouldUseRowspan = groupColumns.includes(dataKey) && itemIndex === 0;
                     
                     if (shouldUseRowspan) {
                         // Only set value for first row of group
                         if (formatter) {
                             v = formatter(v, item);
                         }
-                    } else if (!outletColumns.includes(dataKey)) {
+                    } else if (!groupColumns.includes(dataKey)) {
                         // For non-outlet columns, always show the value
                         if (formatter) {
                             v = formatter(v, item);
@@ -138,7 +138,7 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
                     
                     if (shouldUseRowspan && groupItems.length > 1) {
                         row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}" rowspan="${groupItems.length}">${cellValue}</td>`);
-                    } else if (!outletColumns.includes(dataKey) || itemIndex === 0) {
+                    } else if (!groupColumns.includes(dataKey) || itemIndex === 0) {
                         row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
                     }
                 }

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -26,9 +26,11 @@ const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
  * @param {boolean} isCustomExport - Whether to use custom export columns.
  * @param {string} [tableRowHeaderStyle='background-color: #4a5568; color: white;'] - CSS style string applied to table row headers. Default is dark gray background with white text.
  * @param {boolean} [showTableBorder=true] - Whether to show table borders. Default is true.
+ * @param {string} [groupByKey=null] - Column key to group rows by for rowspan (e.g., 'OutletCode'). When set, rows with same value will be grouped and outlet info will span multiple alert rows.
+ * @param {Array} [outletColumns=null] - Array of column dataKeys that should use rowspan when grouping.
  * @returns {string} HTML table as a string.
  */
-const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true) => {
+const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, outletColumns = null) => {
     if (!rows) {
         return '';
     }
@@ -82,25 +84,89 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
         row.push(escapeHTML(column.title || column.dataKey));
     }
     tableRows.push(`<thead><tr style='${tableRowHeaderStyle}'><th>` + row.join("</th><th>") + "</th></tr></thead>");
-    for (const item of rows) {
-        row = [], rowClass = '';
-        for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
-            let v = item[dataKey];
-            colClass = '';
-            if (formatter) {
-                v = formatter(v, item);
+
+    // Handle grouping with rowspan
+    if (groupByKey && outletColumns) {
+        const grouped = {};
+        const groupOrder = [];
+        
+        // Group rows by the groupByKey
+        rows.forEach(item => {
+            const key = item[groupByKey];
+            if (!grouped[key]) {
+                grouped[key] = [];
+                groupOrder.push(key);
             }
-            if (rowStyle) {
-                rowClass = rowStyle(v, item);
+            grouped[key].push(item);
+        });
+
+        // Build table rows with rowspan
+        groupOrder.forEach(groupKey => {
+            const groupItems = grouped[groupKey];
+            groupItems.forEach((item, itemIndex) => {
+                row = [];
+                rowClass = '';
+                
+                for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
+                    let v = item[dataKey];
+                    colClass = '';
+                    const shouldUseRowspan = outletColumns.includes(dataKey) && itemIndex === 0;
+                    
+                    if (shouldUseRowspan) {
+                        // Only set value for first row of group
+                        if (formatter) {
+                            v = formatter(v, item);
+                        }
+                    } else if (!outletColumns.includes(dataKey)) {
+                        // For non-outlet columns, always show the value
+                        if (formatter) {
+                            v = formatter(v, item);
+                        }
+                    } else {
+                        v = undefined; // Hide value for outlet columns in non-first rows
+                    }
+                    
+                    if (rowStyle) {
+                        rowClass = rowStyle(v, item);
+                    }
+                    if (colStyle) {
+                        colClass = colStyle(v, item);
+                    }
+                    
+                    const tdClass = type === 'number' ? 'table-number' : (rest.colClass ? rest.colClass(v, item) : '');
+                    const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
+                    
+                    if (shouldUseRowspan && groupItems.length > 1) {
+                        row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}" rowspan="${groupItems.length}">${cellValue}</td>`);
+                    } else if (!outletColumns.includes(dataKey) || itemIndex === 0) {
+                        row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
+                    }
+                }
+                tableRows.push(`<tr style="${rowClass}">` + row.join("") + "</tr>");
+            });
+        });
+    } else {
+        // Original behavior without grouping
+        for (const item of rows) {
+            row = [], rowClass = '';
+            for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
+                let v = item[dataKey];
+                colClass = '';
+                if (formatter) {
+                    v = formatter(v, item);
+                }
+                if (rowStyle) {
+                    rowClass = rowStyle(v, item);
+                }
+                if (colStyle) {
+                    colClass = colStyle(v, item);
+                }
+                const tdClass = type === 'number' ? 'table-number' : (rest.colClass ? rest.colClass(v, item) : '');
+                const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
+                row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
             }
-            if (colStyle) {
-                colClass = colStyle(v, item);
-            }
-            const tdClass = type === 'number' ? 'table-number' : (rest.colClass ? rest.colClass(v, item) : '');
-            const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
-            row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
+            tableRows.push(`<tr style="${rowClass}">` + row.join("") + "</tr>");
         }
-        tableRows.push(`<tr style="${rowClass}">` + row.join("") + "</tr>");
     }
 
     if (summaryRow) {

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -19,10 +19,11 @@ const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
 /**
  * Renders a single table cell (<td>) as an HTML string, applying optional formatting, styling, and rowspan.
  *
- * @param {*} value - The value to display in the cell.
- * @param {Object} item - The full data row the cell belongs to.
- * @param {Object} column - Column definition containing optional formatter, type, rowStyle, colStyle, escapeHTMLTags, and colClass.
- * @param {number} [rowspan] - Optional rowspan for merged cells.
+ * @param {Object} params - The parameters object.
+ * @param {*} params.value - The value to display in the cell.
+ * @param {Object} params.item - The full data row the cell belongs to.
+ * @param {Object} params.column - Column definition containing optional formatter, type, rowStyle, colStyle, escapeHTMLTags, and colClass.
+ * @param {number} [params.rowspan] - Optional rowspan for merged cells.
  * @returns {Object} An object containing:
  *   - {string} rowClass - Row-level CSS style returned from column.rowStyle (if any).
  *   - {string} html - The final <td> HTML string with applied styles, classes, formatter, and optional rowspan.
@@ -59,18 +60,19 @@ const renderCell = ({ value, item, column, rowspan }) => {
 /**
  * Converts data rows to an HTML table.
  *
- * @param {Array} rows - The data rows to display.
- * @param {Array} columns - The column definitions.
- * @param {Object} summaryRow - Optional summary row.
- * @param {Object} exportColumns - Optional export column definitions.
- * @param {boolean} isCustomExport - Whether to use custom export columns.
- * @param {string} [tableRowHeaderStyle='background-color: #4a5568; color: white;'] - CSS style string applied to table row headers. Default is dark gray background with white text.
- * @param {boolean} [showTableBorder=true] - Whether to show table borders. Default is true.
- * @param {string} [groupByKey=null] - When set, rows with the same value for this key will be grouped together, and columns specified in rowspanColumns will use rowspan to merge cells across the group.
- * @param {Array} [rowspanColumns=null] - Array of column dataKeys that should use rowspan when grouping.
+ * @param {Object} params - The parameters object.
+ * @param {Array} params.rows - The data rows to display.
+ * @param {Array} [params.columns] - The column definitions.
+ * @param {Object} [params.summaryRow] - Optional summary row.
+ * @param {Object} [params.exportColumns] - Optional export column definitions.
+ * @param {boolean} [params.isCustomExport] - Whether to use custom export columns.
+ * @param {string} [params.tableRowHeaderStyle='background-color: #4a5568; color: white;'] - CSS style string applied to table row headers. Default is dark gray background with white text.
+ * @param {boolean} [params.showTableBorder=true] - Whether to show table borders. Default is true.
+ * @param {string} [params.groupByKey=null] - When set, rows with the same value for this key will be grouped together, and columns specified in rowspanColumns will use rowspan to merge cells across the group.
+ * @param {Array} [params.rowspanColumns=null] - Array of column dataKeys that should use rowspan when grouping.
  * @returns {string} HTML table as a string.
  */
-const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, rowspanColumns = null) => {
+const toHtmlTable = ({ rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, rowspanColumns = null }) => {
     if (!rows) {
         return '';
     }
@@ -504,7 +506,7 @@ const responseTransformer = async function (req, res, next) {
                     if (Object.keys(columns)?.length === 0) {
                         columns = data.columns || {};
                     }
-                    return res.send(toHtmlTable(data, undefined, undefined, columns, true));
+                    return res.send(toHtmlTable({ rows: data, exportColumns: columns, isCustomExport: true }));
                 }
                 break;
             default:

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -17,6 +17,46 @@ const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
     }[tag])) : str;
 
 /**
+ * Renders a single table cell (<td>) as an HTML string, applying optional formatting, styling, and rowspan.
+ *
+ * @param {*} value - The value to display in the cell.
+ * @param {Object} item - The full data row the cell belongs to.
+ * @param {Object} column - Column definition containing optional formatter, type, rowStyle, colStyle, escapeHTMLTags, and colClass.
+ * @param {number} [rowspan] - Optional rowspan for merged cells.
+ * @returns {Object} An object containing:
+ *   - {string} rowClass - Row-level CSS style returned from column.rowStyle (if any).
+ *   - {string} html - The final <td> HTML string with applied styles, classes, formatter, and optional rowspan.
+ */
+const renderCell = ({ value, item, column, rowspan }) => {
+    const { formatter, type, rowStyle, colStyle, escapeHTMLTags = true, colClass: colClassFn } = column;
+
+    let v = value;
+    let rowClass = '';
+    let colClass = '';
+
+    // Apply formatter first to ensure consistent display
+    if (formatter) {
+        v = formatter(v, item);
+    }
+
+    // Apply row and column styles
+    if (rowStyle) {
+        rowClass = rowStyle(v, item);
+    }
+    if (colStyle) {
+        colClass = colStyle(v, item);
+    }
+
+    const tdClass = type === 'number' ? 'table-number' : (colClassFn ? colClassFn(v, item) : '');
+    const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
+
+    // Build the final <td> HTML with optional rowspan
+    const html = `<td${tdClass ? ` class="${tdClass}"` : ''}` + `${colClass ? ` style="${colClass}"` : ''}` + `${rowspan ? ` rowspan="${rowspan}"` : ''}>${cellValue}</td>`;
+
+    return { rowClass, html };
+};
+
+/**
  * Converts data rows to an HTML table.
  *
  * @param {Array} rows - The data rows to display.
@@ -26,11 +66,11 @@ const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
  * @param {boolean} isCustomExport - Whether to use custom export columns.
  * @param {string} [tableRowHeaderStyle='background-color: #4a5568; color: white;'] - CSS style string applied to table row headers. Default is dark gray background with white text.
  * @param {boolean} [showTableBorder=true] - Whether to show table borders. Default is true.
- * @param {string} [groupByKey=null] - Column key to group rows by for rowspan (e.g., 'OutletCode'). When set, rows with same value will be grouped and outlet info will span multiple alert rows.
- * @param {Array} [groupColumns=null] - Array of column dataKeys that should use rowspan when grouping.
+ * @param {string} [groupByKey=null] - When set, rows with the same value for this key will be grouped together, and columns specified in rowspanColumns will use rowspan to merge cells across the group.
+ * @param {Array} [rowspanColumns=null] - Array of column dataKeys that should use rowspan when grouping.
  * @returns {string} HTML table as a string.
  */
-const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, groupColumns = null) => {
+const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, tableRowHeaderStyle = 'background-color: #4a5568; color: white;', showTableBorder = true, groupByKey = null, rowspanColumns = null) => {
     if (!rows) {
         return '';
     }
@@ -86,13 +126,16 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
     tableRows.push(`<thead><tr style='${tableRowHeaderStyle}'><th>` + row.join("</th><th>") + "</th></tr></thead>");
 
     // Handle grouping with rowspan
-    if (groupByKey && groupColumns) {
+    if (groupByKey && rowspanColumns) {
         const grouped = {};
         const groupOrder = [];
-        
-        // Group rows by the groupByKey
-        rows.forEach(item => {
-            const key = item[groupByKey];
+
+        rows.forEach((item, index) => {
+            let key = item[groupByKey];
+            if (key === null || key === undefined || key === '') {
+                // Assign a unique placeholder for empty/null keys
+                key = `__ungrouped__${index}`;
+            }
             if (!grouped[key]) {
                 grouped[key] = [];
                 groupOrder.push(key);
@@ -100,72 +143,49 @@ const toHtmlTable = (rows, columns, summaryRow, exportColumns, isCustomExport, t
             grouped[key].push(item);
         });
 
-        // Build table rows with rowspan
         groupOrder.forEach(groupKey => {
             const groupItems = grouped[groupKey];
+
             groupItems.forEach((item, itemIndex) => {
                 row = [];
                 rowClass = '';
-                
-                for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
-                    let v = item[dataKey];
-                    colClass = '';
-                    const shouldUseRowspan = groupColumns.includes(dataKey) && itemIndex === 0;
-                    
-                    if (shouldUseRowspan) {
-                        // Only set value for first row of group
-                        if (formatter) {
-                            v = formatter(v, item);
-                        }
-                    } else if (!groupColumns.includes(dataKey)) {
-                        // For non-outlet columns, always show the value
-                        if (formatter) {
-                            v = formatter(v, item);
-                        }
-                    } else {
-                        v = undefined; // Hide value for outlet columns in non-first rows
+
+                for (const column of columns) {
+                    const { dataKey } = column;
+                    const isGroupedCol = rowspanColumns.includes(dataKey);
+                    const isFirstRow = itemIndex === 0;
+
+                    // Skip grouped columns for non-first rows
+                    if (isGroupedCol && !isFirstRow) {
+                        continue;
                     }
-                    
-                    if (rowStyle) {
-                        rowClass = rowStyle(v, item);
+
+                    // Render the cell, applying rowspan if needed
+                    const { rowClass: rClass, html } = renderCell({ value: item[dataKey], item, column, rowspan: isGroupedCol && groupItems.length > 1 ? groupItems.length : null });
+                    if (!rowClass) {
+                        rowClass = rClass;
                     }
-                    if (colStyle) {
-                        colClass = colStyle(v, item);
-                    }
-                    
-                    const tdClass = type === 'number' ? 'table-number' : (rest.colClass ? rest.colClass(v, item) : '');
-                    const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
-                    
-                    if (shouldUseRowspan && groupItems.length > 1) {
-                        row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}" rowspan="${groupItems.length}">${cellValue}</td>`);
-                    } else if (!groupColumns.includes(dataKey) || itemIndex === 0) {
-                        row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
-                    }
+                    row.push(html);
                 }
-                tableRows.push(`<tr style="${rowClass}">` + row.join("") + "</tr>");
+
+                tableRows.push(`<tr style="${rowClass}">${row.join('')}</tr>`);
             });
         });
     } else {
-        // Original behavior without grouping
+        // Default behavior without grouping
         for (const item of rows) {
-            row = [], rowClass = '';
-            for (const { dataKey, formatter, type, rowStyle, colStyle, escapeHTMLTags = true, ...rest } of columns) {
-                let v = item[dataKey];
-                colClass = '';
-                if (formatter) {
-                    v = formatter(v, item);
+            row = [];
+            rowClass = '';
+
+            for (const column of columns) {
+                const { rowClass: rClass, html } = renderCell({ value: item[column.dataKey], item, column });
+                if (!rowClass) {
+                    rowClass = rClass;
                 }
-                if (rowStyle) {
-                    rowClass = rowStyle(v, item);
-                }
-                if (colStyle) {
-                    colClass = colStyle(v, item);
-                }
-                const tdClass = type === 'number' ? 'table-number' : (rest.colClass ? rest.colClass(v, item) : '');
-                const cellValue = v === undefined || v === null ? '' : (!escapeHTMLTags ? v : escapeHTML(v));
-                row.push(`<td${tdClass ? ` class="${tdClass}"` : ''} style="${colClass}">${cellValue}</td>`);
+                row.push(html);
             }
-            tableRows.push(`<tr style="${rowClass}">` + row.join("") + "</tr>");
+
+            tableRows.push(`<tr style="${rowClass}">${row.join('')}</tr>`);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Grouping & Rowspan Support:

Added groupByKey and rowspanColumns parameters to allow grouping rows by a key and applying rowspan for repeated values.

Only the first row in each group displays the grouped cell; subsequent rows leave it blank while preserving alignment.