### PR TITLE
Remove serverUrl prefix from hyperlink URL construction

### DIFF
--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -407,7 +407,7 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *    - Normalises data to an array for array-based response types (CSV, XLSX, HTML).
  *    - Runs `updateKeys` on each sheet to rename fields and format date/datetime/boolean/number/percentage values.
  * 5. **Hyperlink URL columns** — for non-XLSX exports, if a column declares `hyperlinkURL` + `hyperlinkIndex`,
- *    appends a `"<Header> - URL"` column whose value is `serverUrl + hyperlinkURL` with `{0}` replaced
+ *    appends a `"<Header> - URL"` column whose value is `hyperlinkURL` with `{0}` replaced
  *    by the row's index-field value.
  * 6. **Sanitise filename** — strips unsafe characters from `options.fileName` (falls back to `req.path`,
  *    then `'export'`) and appends a full timestamp.
@@ -472,10 +472,6 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *   Specifies which columns require lookup substitution via `updateKeys`.
  *   Each entry maps a field key to `{ keyName: string[], lookupKey: string }`.
  *
- * @param {string} [result.serverUrl]
- *   Base URL prepended when building hyperlink values for hyperlink columns.
- *   Example: `"https://app.example.com"` → full URL becomes `"https://app.example.com/records/42"`.
- *
  * @param {boolean} [result.isMultiSheetExport=false]
  *   When `true`, `result[data]` must be an array of sheet descriptors:
  *   `Array<{ title: string, columns: Object, rows: Array<Object> }>`.
@@ -499,7 +495,7 @@ const responseTransformer = async function (req, res, next) {
             return res.status(400).json({ success: false, message: data });
         }
 
-        const exportColumns = others?.exportColumns, userDateFormat = others?.userDateFormat, isElastic = others?.isElastic, userTimezoneOffset = others?.userTimezoneOffset, lookups = others?.lookups, lookupFields = others?.lookupFields, serverUrl = others?.serverUrl;
+        const exportColumns = others?.exportColumns, userDateFormat = others?.userDateFormat, isElastic = others?.isElastic, userTimezoneOffset = others?.userTimezoneOffset, lookups = others?.lookups, lookupFields = others?.lookupFields;
         const dateTimeFormat = userDateFormat + util.dateTimeExportFormat;
         const isMultiSheetExport = others?.isMultiSheetExport || false;
 
@@ -578,7 +574,7 @@ const responseTransformer = async function (req, res, next) {
                     data.forEach((row, index) => {
                         const indexValue = data[index]?.[hyperlinkIndex];
                         if (indexValue !== null && indexValue !== undefined) {
-                            row[urlColumnKey] = (serverUrl || '') + hyperlinkURL.replace('{0}', String(indexValue));
+                            row[urlColumnKey] = hyperlinkURL.replace('{0}', String(indexValue));
                         } else {
                             row[urlColumnKey] = '';
                         }
@@ -602,7 +598,7 @@ const responseTransformer = async function (req, res, next) {
             case mimeTypes.xlsx:
                 res.set('Content-Type', responseType);
                 res.set('Content-Disposition', `attachment; filename="${fileName}.xlsx"`);
-                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, serverUrl });
+                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields });
             case mimeTypes.csv:
                 if (data.length > 0) {
                     data = sanitizeData({ data, columns });

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -18,15 +18,14 @@ const defaultFileType = reportTypes?.excel;
  * @param {string} configuration.stream - If excel should be written to the stream instead of file name with title
  * @param {string} configuration.sheets - Array containing title, rows, columns - for multiple sheets
  * @param {string} configuration.fileName - Optional fileName (not required if stream is used)
- * @param {string} configuration.serverUrl - URL of the server (used for generating links)
  */
-const toExcel = async function ({ title, rows, columns, stream, sheets, fileName, exportColumns = false, userDateFormat, serverUrl = '' }) {
+const toExcel = async function ({ title, rows, columns, stream, sheets, fileName, exportColumns = false, userDateFormat }) {
     const workbook = new ExcelJS.Workbook();
     if (!sheets) {
         sheets = [{ title, rows, columns }];
     }
     for (const sheetDetail of sheets) {
-        await writeExcelSheet({ title, ...sheetDetail, workbook, exportColumns, userDateFormat, serverUrl });
+        await writeExcelSheet({ title, ...sheetDetail, workbook, exportColumns, userDateFormat });
     }
     if (stream) {
         await workbook.xlsx.write(stream);
@@ -56,7 +55,7 @@ function getTableOrSheetName({ name, workbook, isSheetName = true }) {
     return name;
 }
 const operations = { "Mul": "*", "Add": "+", "Sub": "-", "Div": "/" };
-const writeExcelSheet = function ({ title = "main", rows, columns, name, workbook, tableName, exportColumns = false, userDateFormat, serverUrl = '' }) {
+const writeExcelSheet = function ({ title = "main", rows, columns, name, workbook, tableName, exportColumns = false, userDateFormat }) {
     workbook = workbook || new ExcelJS.Workbook();
     name = name || title.replace(sheetName, '');
     name = getTableOrSheetName({ name, workbook })
@@ -138,7 +137,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
                 const sourceRow = rows[rowNumber];
                 const indexValue = sourceRow?.[hyperlinkIndex];
                 if (indexValue === null || indexValue === undefined) continue;
-                const url = serverUrl + hyperlinkURL.replace('{0}', String(indexValue));
+                const url = hyperlinkURL.replace('{0}', String(indexValue));
                 const cell = worksheet.getCell(2 + rowNumber, 1 + colNumber);
                 const displayText = String(cellValue);
                 cell.value = { formula: `HYPERLINK("${url.replace(/"/g, '""')}","${displayText.replace(/"/g, '""')}")` };


### PR DESCRIPTION
Hyperlink columns in both CSV/HTML and XLSX exports were prepending serverUrl to the hyperlinkURL value. Removed serverUrl from the response-transformer middleware, toExcel, and writeExcelSheet — hyperlinkURL is now used as-is, with only the {0} placeholder substituted by the row's index field value.