### PR TITLE
fix: add MM/DD/YYYY inputFormats to Excel parser; drop unused toExcel args

### DIFF
--- a/lib/business/business-base.mjs
+++ b/lib/business/business-base.mjs
@@ -19,13 +19,7 @@ const filterFields = {
     ModifiedByUser: "Modified_"
 }
 
-const dateTimeEnum = {
-    DateTime: 'dateTime',
-    DateTimeLocal: 'dateTimeLocal',
-    LocalDateTime: 'localDateTime'
-}
-
-const dateTypeFields = ["date", "dateTime", "dateTimeLocal", "localDateTime"];
+const dateTypeFields = ["date", "dateTime"];
 
 const IsDeletedColumn = "IsDeleted";
 
@@ -78,11 +72,7 @@ const compareLookups = {
                     values.push(isFirstIndex ? `${v} ${enums.startDateTime}` : `${v} ${enums.endDateTime}`);
                 }
             }
-            if (type === dateTimeEnum.DateTimeLocal) {
-                toReturn = { operator: 'DATETIME', value: v, sqlType: mssql.DateTime }
-            } else {
-                toReturn = { operator: 'BETWEEN', value: values, sqlType: mssql.VarChar, type: type };
-            }
+            toReturn = { operator: 'BETWEEN', value: values, sqlType: mssql.VarChar, type: type };
         } else {
             toReturn = { operator: '=', value: v, type: type };
         }
@@ -95,36 +85,21 @@ const compareLookups = {
                 const isFirstIndex = index === 0;
                 values.push(isFirstIndex ? `${v} ${enums.startDateTime}` : `${v} ${enums.endDateTime}`);
             }
-            if (type === dateTimeEnum.DateTimeLocal) {
-                return { operator: 'NOT BETWEEN DATE', value: v, sqlType: mssql.DateTime, type: type };
-            }
             return { operator: 'NOT BETWEEN', value: values, sqlType: mssql.VarChar, type: type };
         } else {
             return { operator: '!=', value: v, type: type };
         }
     },
     "onOrAfter": function ({ v, type }) {
-        if (type === dateTimeEnum.DateTimeLocal) {
-            return { operator: '>=', value: `${v}`, type: type };
-        }
         return { operator: '>=', value: `${v} ${enums.startDateTime}`, type: type };
     },
     "onOrBefore": function ({ v, type }) {
-        if (type === dateTimeEnum.DateTimeLocal) {
-            return { operator: '<=', value: `${v}`, type: type };
-        }
         return { operator: '<=', value: `${v} ${enums.endDateTime}`, type: type };
     },
     "after": function ({ v, type }) {
-        if (type === dateTimeEnum.DateTimeLocal) {
-            return { operator: '>', value: `${v}`, type: type };
-        }
         return { operator: '>', value: `${v} ${enums.endDateTime}`, type: type };
     },
     "before": function ({ v, type }) {
-        if (type === dateTimeEnum.DateTimeLocal) {
-            return { operator: '<', value: `${v}`, type: type };
-        }
         return { operator: '<', value: `${v} ${enums.startDateTime}`, type: type };
     },
     "isAnyOf": function ({ v, type }) {

--- a/lib/business/business-base.mjs
+++ b/lib/business/business-base.mjs
@@ -21,10 +21,11 @@ const filterFields = {
 
 const dateTimeEnum = {
     DateTime: 'dateTime',
-    DateTimeLocal: 'dateTimeLocal'
+    DateTimeLocal: 'dateTimeLocal',
+    LocalDateTime: 'localDateTime'
 }
 
-const dateTypeFields = ["date", "dateTime", "dateTimeLocal"];
+const dateTypeFields = ["date", "dateTime", "dateTimeLocal", "localDateTime"];
 
 const IsDeletedColumn = "IsDeleted";
 

--- a/lib/enums.mjs
+++ b/lib/enums.mjs
@@ -1,5 +1,5 @@
 export default {
-    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal'],
+    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'],
     dateTimeExportFormat: ' hh:mm:ss A',
     dateTimeCSVExportFormat: '-hh:mm:ss A',
     fullDateFormat: 'YYYY-MM-DDTHH-mm-ss',

--- a/lib/enums.mjs
+++ b/lib/enums.mjs
@@ -1,5 +1,5 @@
 export default {
-    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'],
+    dateTimeFields: ['date', 'dateTime'],
     dateTimeExportFormat: ' hh:mm:ss A',
     dateTimeCSVExportFormat: '-hh:mm:ss A',
     fullDateFormat: 'YYYY-MM-DDTHH-mm-ss',

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -234,6 +234,7 @@ const ensureArray = function (data) {
  * @param {Object} params.keyMapping - An object mapping original keys to new keys.
  * @param {Object} params.columns - An object describing each column's value type and options.
  * @param {boolean} [params.isForXML=false] - Whether to use XML key names.
+ * @param {boolean} [params.isForXlsx=false] - When true, skips date/dateTime string formatting so raw values are preserved for the Excel writer to convert to Date objects.
  * @param {string} params.userDateFormat - The date format to use for date fields.
  * @param {string} params.userDateTimeFormat - The date-time format to use for date-time fields.
  * @param {string} params.userTimezone - The user's timezone (e.g., 'America/New_York').
@@ -241,7 +242,7 @@ const ensureArray = function (data) {
  * @param {Object} [params.lookupFields={}] - Fields that require lookup transformation.
  * @returns {Array<Object>} The transformed array of data records with updated keys and formatted values.
  */
-const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezone, lookups, lookupFields = {} }) {
+const updateKeys = function ({ data, keyMapping, columns, isForXML = false, isForXlsx = false, userDateFormat, userDateTimeFormat, userTimezone, lookups, lookupFields = {} }) {
     if (!data || !Array.isArray(data) || data.length === 0) {
         return [];
     }
@@ -258,7 +259,7 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
 
                 const isParsable = columns[ele]?.isParsable !== false ? true : columns[ele]?.isParsable;
 
-                if (util.dateTimeFields.includes(valueType)) {
+                if (util.dateTimeFields.includes(valueType) && !isForXlsx) {
                     value = util.transformDateTime({ value, valueType, userDateFormat, userDateTimeFormat, userTimezone, localize });
                 } else if (valueType === 'boolean') {
                     value = value === true || value === 1 ? 'Yes' : 'No';
@@ -542,7 +543,7 @@ const responseTransformer = async function (req, res, next) {
                 sheets = isMultiSheetExport ? data : [{ title: "Main", columns, rows: data }];
                 for (const sheet of sheets) {
                     if (sheet.rows && sheet.rows.length > 0) {
-                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezone, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType) });
+                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezone, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType), isForXlsx: responseType === mimeTypes.xlsx });
                     }
                 }
             }

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -616,7 +616,7 @@ const responseTransformer = async function (req, res, next) {
             case mimeTypes.xlsx:
                 res.set('Content-Type', responseType);
                 res.set('Content-Disposition', `attachment; filename="${fileName}.xlsx"`);
-                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, lookups, lookupFields });
+                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat });
             case mimeTypes.csv:
                 if (data.length > 0) {
                     data = sanitizeData({ data, columns });

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -247,7 +247,7 @@ const formatDateTime = function ({ value, format }) {
  * @param {number} params.userTimezoneOffset - The user's timezone offset in minutes.
  * @param {Object} params.lookups - Lookup objects for mapping values to labels.
  * @param {Object} [params.lookupFields={}] - Fields that require lookup transformation.
- * @param {Object} [params.responseType] - Export File Type.
+ * @param {string} [params.responseType] - Export MIME type / file type.
  * @returns {Array<Object>} The transformed array of data records with updated keys and formatted values.
  */
 const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {}, responseType }) {

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -252,10 +252,9 @@ const formatDateTime = function ({ value, format, localize = false }) {
  * @param {number} params.userTimezoneOffset - The user's timezone offset in minutes.
  * @param {Object} params.lookups - Lookup objects for mapping values to labels.
  * @param {Object} [params.lookupFields={}] - Fields that require lookup transformation.
- * @param {string} [params.responseType] - Export MIME type / file type.
  * @returns {Array<Object>} The transformed array of data records with updated keys and formatted values.
  */
-const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {}, responseType }) {
+const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {} }) {
     if (!data || !Array.isArray(data) || data.length === 0) {
         return [];
     }
@@ -463,7 +462,7 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *
  * @param {number} [result.userTimezoneOffset]
  *   The user's UTC offset in **minutes**. Applied to dateTime fields via `dayjs.utc().add(offset, 'minute')`
- *   unless `localize` is set on the column.
+ *   when `localize` is set to `true` on the column.
  *
  * @param {boolean} [result.isElastic=false]
  *   When `true`, data is assumed to come from Elasticsearch. Key mapping uses `exportColumn.field`
@@ -527,7 +526,7 @@ const responseTransformer = async function (req, res, next) {
             for (const key in exportColumns) {
                 const exportColumn = exportColumns[key];
 
-                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex, field: exportColumn.field };
+                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex, field: exportColumn.field, localize: exportColumn.localize };
 
                 columns[key] = { ...commonProperties };
 

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -513,7 +513,7 @@ const responseTransformer = async function (req, res, next) {
             return res.status(400).json({ success: false, message: data });
         }
 
-        const exportColumns = others?.exportColumns, userDateFormat = others?.userDateFormat, isElastic = others?.isElastic, userTimezoneOffset = others?.userTimezoneOffset, lookups = others?.lookups, lookupFields = others?.lookupFields;
+        const { exportColumns, userDateFormat, isElastic, userTimezoneOffset, lookups, lookupFields } = others;
         const dateTimeFormat = userDateFormat + util.dateTimeExportFormat;
         const isMultiSheetExport = others?.isMultiSheetExport || false;
 
@@ -581,6 +581,21 @@ const responseTransformer = async function (req, res, next) {
                 }
             }
             data = sheets[0].rows;
+
+            if (responseType !== mimeTypes.xlsx && data) {
+                Object.values(columns).forEach((column) => {
+                    const { localize, valueType, field, name } = column;
+                    data.forEach((row, index) => {
+                        if (util.dateTimeFields.includes(valueType)) {
+                            let value = data[index]?.[field] || data[index]?.[name];
+                            const format = valueType === 'date' ? userDateFormat : dateTimeFormat;
+                            value = localize ? dayjs.utc(value).format(format) : dayjs(value).format(format);
+                            data[index][field] = value;
+                            data[index][name] = value;
+                        }
+                    })
+                })
+            }
 
             if (responseType !== mimeTypes.xlsx && data && hyperlinkCols.length > 0) {
                 const isForXML = isForXMLResponseType.includes(responseType);

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -247,9 +247,10 @@ const formatDateTime = function ({ value, format }) {
  * @param {number} params.userTimezoneOffset - The user's timezone offset in minutes.
  * @param {Object} params.lookups - Lookup objects for mapping values to labels.
  * @param {Object} [params.lookupFields={}] - Fields that require lookup transformation.
+ * @param {Object} [params.responseType] - Export File Type.
  * @returns {Array<Object>} The transformed array of data records with updated keys and formatted values.
  */
-const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {} }) {
+const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {}, responseType }) {
     if (!data || !Array.isArray(data) || data.length === 0) {
         return [];
     }
@@ -270,7 +271,7 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
                     if (value !== null && value !== undefined) {
                         if (userTimezoneOffset && !keepUTC) {
                             if (valueType === 'localDateTime') {
-                                value = dayjs(value).utc();
+                                value = responseType === mimeTypes.xlsx ? dayjs(value).utc() : dayjs(value).utc().format(valueType === 'date' ? userDateFormat : userDateTimeFormat);
                             } else {
                                 value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute')
                             }
@@ -564,7 +565,7 @@ const responseTransformer = async function (req, res, next) {
                 sheets = isMultiSheetExport ? data : [{ title: "Main", columns, rows: data }];
                 for (const sheet of sheets) {
                     if (sheet.rows && sheet.rows.length > 0) {
-                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType) });
+                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType), responseType });
                     }
                 }
             }

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -2,13 +2,8 @@ import ObjectsToCsv from 'objects-to-csv';
 import { toExcel } from '../reports.mjs';
 import js2xmlparser from 'js2xmlparser';
 import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc.js';
-import timezone from 'dayjs/plugin/timezone.js';
 import util from '../util.js';
 import enums from '../enums.mjs';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
     tag => ({
@@ -433,7 +428,7 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *     field:         string,   // Key in the source data record (used for Elastic / plain-array data).
  *     type:          string,   // Value type: 'date' | 'dateTime' | 'number' | 'boolean' | 'percentage'.
  *     width:         number,   // Column width (pixels); divided by excelColumnWidthEnum for XLSX.
- *     localize:      boolean,  // Apply user's timezone offset for this column when true.
+ *     localize:      boolean,  // When true, assumes the value is UTC and converts to the IANA timezone in userTimezone; falls back to local timezone if userTimezone is not provided.
  *     isParsable:    boolean,  // When false, skips parseInt for number-typed columns.
  *     hyperlinkURL:  string,   // URL template with a {0} placeholder, e.g. '/records/{0}'.
  *     hyperlinkIndex: string,  // Field key whose value is substituted into {0} in hyperlinkURL.

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -3,10 +3,12 @@ import { toExcel } from '../reports.mjs';
 import js2xmlparser from 'js2xmlparser';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import util from '../util.js';
 import enums from '../enums.mjs';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
     tag => ({
@@ -228,32 +230,6 @@ const ensureArray = function (data) {
     return data;
 }
 
-/**
- * Formats a date/time value based on the provided format and localization settings.
- *
- * @param {Object} params - The parameters for formatting.
- * @param {*} params.value - The date/time value to format.
- * @param {string} params.format - The dayjs format string.
- * @param {boolean} [params.localize=false] - Whether to apply the user's timezone offset.
- * @param {number} [params.userTimezoneOffset] - The user's timezone offset in minutes.
- * @returns {string} The formatted date/time string.
- */
-const formatDateTime = function ({ value, format, localize = false, userTimezoneOffset }) {
-    if (!value) {
-        return '';
-    }
-    const langL = 'en';
-    let d = dayjs.utc(value);
-    if (localize) {
-        if (userTimezoneOffset !== undefined && userTimezoneOffset !== null) {
-            d = d.utcOffset(Number(userTimezoneOffset));
-        } else {
-            // Fallback to machine local if localization is requested but no offset is provided
-            d = dayjs(value);
-        }
-    }
-    return d.locale(langL).format(format);
-}
 
 /**
  * Transforms an array of data objects by updating their keys and formatting values based on provided mappings and options.
@@ -265,12 +241,12 @@ const formatDateTime = function ({ value, format, localize = false, userTimezone
  * @param {boolean} [params.isForXML=false] - Whether to use XML key names.
  * @param {string} params.userDateFormat - The date format to use for date fields.
  * @param {string} params.userDateTimeFormat - The date-time format to use for date-time fields.
- * @param {number} params.userTimezoneOffset - The user's timezone offset in minutes.
+ * @param {string} params.userTimezone - The user's timezone (e.g., 'America/New_York').
  * @param {Object} params.lookups - Lookup objects for mapping values to labels.
  * @param {Object} [params.lookupFields={}] - Fields that require lookup transformation.
  * @returns {Array<Object>} The transformed array of data records with updated keys and formatted values.
  */
-const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezoneOffset, lookups, lookupFields = {} }) {
+const updateKeys = function ({ data, keyMapping, columns, isForXML = false, userDateFormat, userDateTimeFormat, userTimezone, lookups, lookupFields = {} }) {
     if (!data || !Array.isArray(data) || data.length === 0) {
         return [];
     }
@@ -288,11 +264,7 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
                 const isParsable = columns[ele]?.isParsable !== false ? true : columns[ele]?.isParsable;
 
                 if (util.dateTimeFields.includes(valueType)) {
-                    if (value !== null && value !== undefined) {
-                        value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat, localize, userTimezoneOffset });
-                    } else {
-                        value = '';
-                    }
+                    value = util.transformDateTime({ value, valueType, userDateFormat, userDateTimeFormat, userTimezone, localize });
                 } else if (valueType === 'boolean') {
                     value = value === true || value === 1 ? 'Yes' : 'No';
                 } else if (valueType === 'number' && isParsable) {
@@ -473,9 +445,8 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *   A dayjs-compatible format string applied to `date`-typed columns (e.g. `"MM/DD/YYYY"`).
  *   Datetime columns use this value concatenated with `util.dateTimeExportFormat`.
  *
- * @param {number} [result.userTimezoneOffset]
- *   The user's UTC offset in **minutes**. Applied to dateTime fields by setting the Dayjs instance
- *   offset via `utcOffset(Number(userTimezoneOffset))` when `localize` is set to `true` on the column.
+ * @param {string} [result.userTimezone]
+ *   The user's timezone (e.g., 'America/New_York'). Applied to dateTime fields when `localize` is set to `true` on the column.
  *
  * @param {boolean} [result.isElastic=false]
  *   When `true`, data is assumed to come from Elasticsearch. Key mapping uses `exportColumn.field`
@@ -513,7 +484,7 @@ const responseTransformer = async function (req, res, next) {
             return res.status(400).json({ success: false, message: data });
         }
 
-        const { exportColumns, userDateFormat, isElastic, userTimezoneOffset, lookups, lookupFields } = others;
+        const { exportColumns, userDateFormat, isElastic, userTimezone, lookups, lookupFields } = others;
         const dateTimeFormat = userDateFormat + util.dateTimeExportFormat;
         const isMultiSheetExport = others?.isMultiSheetExport || false;
 
@@ -576,26 +547,12 @@ const responseTransformer = async function (req, res, next) {
                 sheets = isMultiSheetExport ? data : [{ title: "Main", columns, rows: data }];
                 for (const sheet of sheets) {
                     if (sheet.rows && sheet.rows.length > 0) {
-                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType) });
+                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezone, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType) });
                     }
                 }
             }
             data = sheets[0].rows;
 
-            if (responseType !== mimeTypes.xlsx && data) {
-                Object.values(columns).forEach((column) => {
-                    const { localize, valueType, field, name } = column;
-                    data.forEach((row, index) => {
-                        if (util.dateTimeFields.includes(valueType)) {
-                            let value = data[index]?.[field] || data[index]?.[name];
-                            const format = valueType === 'date' ? userDateFormat : dateTimeFormat;
-                            value = localize ? dayjs.utc(value).format(format) : dayjs(value).format(format);
-                            data[index][field] = value;
-                            data[index][name] = value;
-                        }
-                    })
-                })
-            }
 
             if (responseType !== mimeTypes.xlsx && data && hyperlinkCols.length > 0) {
                 const isForXML = isForXMLResponseType.includes(responseType);
@@ -623,7 +580,7 @@ const responseTransformer = async function (req, res, next) {
                 res.set('Content-Type', 'application/json');
                 if (exportColumns && Object.keys(exportColumns)?.length > 0) {
                     if (!isExportOperation) {
-                        data = updateKeys({ data, keyMapping: columnKeyMappings, columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields });
+                        data = updateKeys({ data, keyMapping: columnKeyMappings, columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezone, lookups, lookupFields });
                     }
                     jsonResponse = data;
                 }

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -269,9 +269,15 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
                 if (util.dateTimeFields.includes(valueType)) {
                     if (value !== null && value !== undefined) {
                         if (userTimezoneOffset && !keepUTC) {
-                            value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute')
+                            if (valueType === 'localDateTime') {
+                                value = dayjs(value).utc();
+                            } else {
+                                value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute')
+                            }
                         }
-                        value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat });
+                        if (valueType !== 'localDateTime') {
+                            value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat });
+                        }
                     } else {
                         value = '';
                     }
@@ -521,7 +527,7 @@ const responseTransformer = async function (req, res, next) {
             for (const key in exportColumns) {
                 const exportColumn = exportColumns[key];
 
-                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, keepUTC: exportColumn.keepUTC, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex };
+                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, keepUTC: exportColumn.keepUTC, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex, field: exportColumn.field };
 
                 columns[key] = { ...commonProperties };
 

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -563,7 +563,7 @@ const responseTransformer = async function (req, res, next) {
                 sheets = isMultiSheetExport ? data : [{ title: "Main", columns, rows: data }];
                 for (const sheet of sheets) {
                     if (sheet.rows && sheet.rows.length > 0) {
-                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType), responseType });
+                        sheet.rows = updateKeys({ data: sheet.rows, keyMapping: isMultiSheetExport ? sheet.columns : columnKeyMappings, columns: sheet.columns, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields, isForXML: isForXMLResponseType.includes(responseType) });
                     }
                 }
             }

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -228,15 +228,31 @@ const ensureArray = function (data) {
     return data;
 }
 
-const formatDateTime = function ({ value, format, localize = false }) {
+/**
+ * Formats a date/time value based on the provided format and localization settings.
+ *
+ * @param {Object} params - The parameters for formatting.
+ * @param {*} params.value - The date/time value to format.
+ * @param {string} params.format - The dayjs format string.
+ * @param {boolean} [params.localize=false] - Whether to apply the user's timezone offset.
+ * @param {number} [params.userTimezoneOffset] - The user's timezone offset in minutes.
+ * @returns {string} The formatted date/time string.
+ */
+const formatDateTime = function ({ value, format, localize = false, userTimezoneOffset }) {
     if (!value) {
         return '';
     }
     const langL = 'en';
+    let d = dayjs.utc(value);
     if (localize) {
-        return dayjs(value).locale(langL).format(format);
+        if (userTimezoneOffset !== undefined && userTimezoneOffset !== null) {
+            d = d.utcOffset(Number(userTimezoneOffset));
+        } else {
+            // Fallback to machine local if localization is requested but no offset is provided
+            d = dayjs(value);
+        }
     }
-    return dayjs.utc(value).locale(langL).format(format);
+    return d.locale(langL).format(format);
 }
 
 /**
@@ -273,10 +289,7 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
 
                 if (util.dateTimeFields.includes(valueType)) {
                     if (value !== null && value !== undefined) {
-                        if (userTimezoneOffset && localize) {
-                            value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute');
-                        }
-                        value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat, localize });
+                        value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat, localize, userTimezoneOffset });
                     } else {
                         value = '';
                     }
@@ -603,7 +616,7 @@ const responseTransformer = async function (req, res, next) {
             case mimeTypes.xlsx:
                 res.set('Content-Type', responseType);
                 res.set('Content-Disposition', `attachment; filename="${fileName}.xlsx"`);
-                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, userTimezoneOffset, lookups, lookupFields });
+                return await toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, lookups, lookupFields });
             case mimeTypes.csv:
                 if (data.length > 0) {
                     data = sanitizeData({ data, columns });

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -2,8 +2,11 @@ import ObjectsToCsv from 'objects-to-csv';
 import { toExcel } from '../reports.mjs';
 import js2xmlparser from 'js2xmlparser';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
 import util from '../util.js';
 import enums from '../enums.mjs';
+
+dayjs.extend(utc);
 
 const escapeHTML = str => typeof str === 'string' ? str.replace(/[&<>'"]/g,
     tag => ({
@@ -225,13 +228,15 @@ const ensureArray = function (data) {
     return data;
 }
 
-const formatDateTime = function ({ value, format }) {
+const formatDateTime = function ({ value, format, localize = false }) {
     if (!value) {
         return '';
     }
     const langL = 'en';
-    const dateShow = ((typeof value === 'string') && value.includes('T')) ? dayjs(value).locale(langL).utc().format(format) : dayjs(value).locale(langL).format(format);
-    return dateShow;
+    if (localize) {
+        return dayjs(value).locale(langL).format(format);
+    }
+    return dayjs.utc(value).locale(langL).format(format);
 }
 
 /**
@@ -261,7 +266,7 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
         for (const ele of Object.keys(keyMapping)) {
             if (columns[ele]) {
                 const keyName = isForXML ? ele : keyMapping[ele];
-                const { valueType, keepUTC = false } = columns[ele];
+                const { valueType, localize = false } = columns[ele];
 
                 let value = record[ele];
 
@@ -269,16 +274,10 @@ const updateKeys = function ({ data, keyMapping, columns, isForXML = false, user
 
                 if (util.dateTimeFields.includes(valueType)) {
                     if (value !== null && value !== undefined) {
-                        if (userTimezoneOffset && !keepUTC) {
-                            if (valueType === 'localDateTime') {
-                                value = responseType === mimeTypes.xlsx ? dayjs(value).utc() : dayjs(value).utc().format(valueType === 'date' ? userDateFormat : userDateTimeFormat);
-                            } else {
-                                value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute')
-                            }
+                        if (userTimezoneOffset && localize) {
+                            value = dayjs.utc(value).add(Number(userTimezoneOffset), 'minute');
                         }
-                        if (valueType !== 'localDateTime') {
-                            value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat });
-                        }
+                        value = formatDateTime({ value, format: valueType === 'date' ? userDateFormat : userDateTimeFormat, localize });
                     } else {
                         value = '';
                     }
@@ -412,7 +411,7 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *    - Registers hyperlink index columns as hidden `isHyperLinkColumn` entries.
  *    - Applies lookup replacement via `updateLookups`.
  *    - Normalises data to an array for array-based response types (CSV, XLSX, HTML).
- *    - Runs `updateKeys` on each sheet to rename fields and format date/datetime/boolean/number/percentage values.
+ *    - Runs `updateKeys` on each sheet to rename fields and format date/dateTime/boolean/number/percentage values.
  * 5. **Hyperlink URL columns** — for non-XLSX exports, if a column declares `hyperlinkURL` + `hyperlinkIndex`,
  *    appends a `"<Header> - URL"` column whose value is `hyperlinkURL` with `{0}` replaced
  *    by the row's index-field value.
@@ -448,9 +447,9 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *   {
  *     headerName:    string,   // Column header / display name used in the output file.
  *     field:         string,   // Key in the source data record (used for Elastic / plain-array data).
- *     type:          string,   // Value type: 'date' | 'datetime' | 'number' | 'boolean' | 'percentage'.
+ *     type:          string,   // Value type: 'date' | 'dateTime' | 'number' | 'boolean' | 'percentage'.
  *     width:         number,   // Column width (pixels); divided by excelColumnWidthEnum for XLSX.
- *     keepUTC:       boolean,  // Skip timezone-offset conversion for this column when true.
+ *     localize:      boolean,  // Apply user's timezone offset for this column when true.
  *     isParsable:    boolean,  // When false, skips parseInt for number-typed columns.
  *     hyperlinkURL:  string,   // URL template with a {0} placeholder, e.g. '/records/{0}'.
  *     hyperlinkIndex: string,  // Field key whose value is substituted into {0} in hyperlinkURL.
@@ -463,8 +462,8 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *   Datetime columns use this value concatenated with `util.dateTimeExportFormat`.
  *
  * @param {number} [result.userTimezoneOffset]
- *   The user's UTC offset in **minutes**. Applied to datetime fields via `dayjs.utc().add(offset, 'minute')`
- *   unless `keepUTC` is set on the column.
+ *   The user's UTC offset in **minutes**. Applied to dateTime fields via `dayjs.utc().add(offset, 'minute')`
+ *   unless `localize` is set on the column.
  *
  * @param {boolean} [result.isElastic=false]
  *   When `true`, data is assumed to come from Elasticsearch. Key mapping uses `exportColumn.field`
@@ -528,7 +527,7 @@ const responseTransformer = async function (req, res, next) {
             for (const key in exportColumns) {
                 const exportColumn = exportColumns[key];
 
-                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, keepUTC: exportColumn.keepUTC, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex, field: exportColumn.field };
+                const commonProperties = { width: exportColumn.width / util.excelColumnWidthEnum, name: exportColumn.headerName, valueType: exportColumn.type, isParsable: exportColumn.isParsable, hyperlinkURL: exportColumn.hyperlinkURL, hyperlinkIndex: exportColumn.hyperlinkIndex, field: exportColumn.field };
 
                 columns[key] = { ...commonProperties };
 

--- a/lib/middleware/response-transformer.mjs
+++ b/lib/middleware/response-transformer.mjs
@@ -474,8 +474,8 @@ const sanitizeData = ({ data, columns = {}, responseType }) => {
  *   Datetime columns use this value concatenated with `util.dateTimeExportFormat`.
  *
  * @param {number} [result.userTimezoneOffset]
- *   The user's UTC offset in **minutes**. Applied to dateTime fields via `dayjs.utc().add(offset, 'minute')`
- *   when `localize` is set to `true` on the column.
+ *   The user's UTC offset in **minutes**. Applied to dateTime fields by setting the Dayjs instance
+ *   offset via `utcOffset(Number(userTimezoneOffset))` when `localize` is set to `true` on the column.
  *
  * @param {boolean} [result.isElastic=false]
  *   When `true`, data is assumed to come from Elasticsearch. Key mapping uses `exportColumn.field`

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -104,7 +104,15 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
     for (const row of rows) {
         const rowData = [];
         for (const key of keys) {
-            rowData.push(row[key] ?? null);
+            let value = row[key] ?? null;
+            const colConfig = columns[key];
+            if (value !== null && colConfig && ['date', 'dateTime'].includes(colConfig.valueType)) {
+                const parsed = dayjs.utc(value);
+                if (parsed.isValid()) {
+                    value = parsed.toDate();
+                }
+            }
+            rowData.push(value);
         }
         tableRows.push(rowData);
     }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -9,25 +9,11 @@ import util from './util.js';
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 
-const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat, dateTimeExcelRowExportFormat } = util;
+const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat, dateTimeExcelRowExportFormat, dateTimeInputFormats } = util;
 
 const sheetName = /[^\w\s-]/gi;
 const tableNameRegex = /[^\w]/gi
 const defaultFileType = reportTypes?.excel;
-const inputFormats = [
-    'MM/DD/YYYY hh:mm:ss A',
-    'MM/DD/YYYY HH:mm:ss A',
-    'MM/DD/YYYY HH:mm:ss',
-    'MM/DD/YYYY',
-    'DD-MM-YYYY hh:mm:ss A',
-    'DD-MM-YYYY HH:mm:ss',
-    'DD-MM-YYYY',
-    'YYYY-MM-DD',
-    'YYYY-MM-DD HH:mm:ss',
-    'YYYY-MM-DDTHH:mm:ss',
-    'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
-    'YYYY-MM-DDTHH:mm:ss[Z]'
-];
 
 /**
  * 
@@ -127,7 +113,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             const dateConfig = rowsWithDateFields[key];
             if (dateConfig && value) {
                 const { format: outputFormat, localize } = dateConfig;
-                const parsed = localize ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
+                const parsed = localize ? dayjs.utc(value, dateTimeInputFormats, true) : dayjs(value, dateTimeInputFormats, true);
                 value = parsed.isValid() ? parsed.format(outputFormat) : value;
             }
             rowData.push(value ?? null);

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -107,7 +107,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             let value = row[key] ?? null;
             const colConfig = columns[key];
             if (value !== null && !(value instanceof Date) && colConfig && ['date', 'dateTime'].includes(colConfig.valueType)) {
-                const parsed = dayjs.utc(value);
+                const parsed = colConfig.valueType === 'date' ? dayjs(value) : dayjs.utc(value);
                 if (parsed.isValid()) {
                     value = parsed.toDate();
                 }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -87,9 +87,9 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             const { title: colTitle, callback, ...others } = colConfig;
             name = colTitle || name;
             if (Object.keys(others).length > 0) {
-                if (['date', 'datetime', 'dateTime', 'dateTimeLocal'].includes(others.valueType)) {
+                if (['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'].includes(others.valueType)) {
                     others.numFmt = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
-                    rowsWithDateFields[others.name] = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
+                    rowsWithDateFields[others.valueType === 'localDateTime' ? others.field : others.name] = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
                 }
                 colFormats.push({ ...others, index });
             }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -3,12 +3,27 @@ import fse from "fs-extra";
 import { Readable } from 'stream';
 import logger from './logger.js';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 import util from './util.js';
+dayjs.extend(utc);
+dayjs.extend(customParseFormat);
+
+console.log('customParseFormat -> ', customParseFormat);
 const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat, dateTimeExcelRowExportFormat } = util;
 
 const sheetName = /[^\w\s-]/gi;
 const tableNameRegex = /[^\w]/gi
 const defaultFileType = reportTypes?.excel;
+const inputFormats = [
+    'DD-MM-YYYY hh:mm:ss A',
+    'DD-MM-YYYY HH:mm:ss',
+    'YYYY-MM-DD HH:mm:ss',
+    'YYYY-MM-DDTHH:mm:ss',
+    'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+    'YYYY-MM-DDTHH:mm:ss[Z]'
+];
+
 /**
  * 
  * @param {Object} configuration
@@ -87,9 +102,11 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             const { title: colTitle, callback, ...others } = colConfig;
             name = colTitle || name;
             if (Object.keys(others).length > 0) {
-                if (['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'].includes(others.valueType)) {
-                    others.numFmt = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
-                    rowsWithDateFields[others.valueType === 'localDateTime' ? (others.field || others.name) : others.name] = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
+                if (['date', 'dateTime'].includes(others.valueType)) {
+                    const format = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
+                    const rowFormat = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
+                    others.numFmt = format;
+                    rowsWithDateFields[key] = { format: rowFormat, localize: others.localize === true };
                 }
                 colFormats.push({ ...others, index });
             }
@@ -101,11 +118,14 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
     for (const row of rows) {
         const rowData = [];
         for (const key of keys) {
-            if (Object.keys(rowsWithDateFields).includes(key) && row[key]) {
-                const format = rowsWithDateFields[key]
-                row[key] = dayjs(row[key]).format(format)
+            let value = row[key];
+            const dateConfig = rowsWithDateFields[key];
+            if (dateConfig && value) {
+                const { format: outputFormat, localize } = dateConfig;
+                const parsed = localize ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
+                value = parsed.isValid() ? parsed.format(outputFormat) : value;
             }
-            rowData.push(row[key] ?? null);
+            rowData.push(value ?? null);
         }
         tableRows.push(rowData);
     }
@@ -245,11 +265,11 @@ const render = async function ({ reportName, title, rows, toFile, columns, sheet
     if (toFile) {
         const reportHandler = handlers[reportType];
         if (typeof reportHandler !== "function") {
-            logger.error({ 
-                reportType, 
+            logger.error({
+                reportType,
                 availableHandlers: Object.keys(handlers),
                 reportName,
-                title 
+                title
             }, `Report handler not defined for type: ${reportType}`);
             return;
         }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -106,7 +106,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
         for (const key of keys) {
             let value = row[key] ?? null;
             const colConfig = columns[key];
-            if (value !== null && colConfig && ['date', 'dateTime'].includes(colConfig.valueType)) {
+            if (value !== null && !(value instanceof Date) && colConfig && ['date', 'dateTime'].includes(colConfig.valueType)) {
                 const parsed = dayjs.utc(value);
                 if (parsed.isValid()) {
                     value = parsed.toDate();

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -4,12 +4,10 @@ import { Readable } from 'stream';
 import logger from './logger.js';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
-import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 import util from './util.js';
 dayjs.extend(utc);
-dayjs.extend(customParseFormat);
 
-const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat, dateTimeExcelRowExportFormat, dateTimeInputFormats } = util;
+const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat } = util;
 
 const sheetName = /[^\w\s-]/gi;
 const tableNameRegex = /[^\w]/gi
@@ -82,7 +80,6 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
         }
     }
     const colFormats = [];
-    const rowsWithDateFields = {}
     let index = 0;
     for (const key of keys) {
         index++;
@@ -95,9 +92,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             if (Object.keys(others).length > 0) {
                 if (['date', 'dateTime'].includes(others.valueType)) {
                     const format = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
-                    const rowFormat = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
                     others.numFmt = format;
-                    rowsWithDateFields[key] = { format: rowFormat, localize: others.localize === true };
                 }
                 colFormats.push({ ...others, index });
             }
@@ -109,14 +104,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
     for (const row of rows) {
         const rowData = [];
         for (const key of keys) {
-            let value = row[key];
-            const dateConfig = rowsWithDateFields[key];
-            if (dateConfig && value) {
-                const { format: outputFormat, localize } = dateConfig;
-                const parsed = localize ? dayjs.utc(value, dateTimeInputFormats, true) : dayjs(value, dateTimeInputFormats, true);
-                value = parsed.isValid() ? parsed.format(outputFormat) : value;
-            }
-            rowData.push(value ?? null);
+            rowData.push(row[key] ?? null);
         }
         tableRows.push(rowData);
     }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -105,7 +105,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
                     const format = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
                     const rowFormat = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
                     others.numFmt = format;
-                    rowsWithDateFields[key] = { format: rowFormat, parseAsUTC: others.localize === true };
+                    rowsWithDateFields[key] = { format: rowFormat, localize: others.localize === true };
                 }
                 colFormats.push({ ...others, index });
             }
@@ -120,8 +120,8 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             let value = row[key];
             const dateConfig = rowsWithDateFields[key];
             if (dateConfig && value) {
-                const { format: outputFormat, parseAsUTC } = dateConfig;
-                const parsed = parseAsUTC ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
+                const { format: outputFormat, localize } = dateConfig;
+                const parsed = localize ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
                 value = parsed.isValid() ? parsed.format(outputFormat) : value;
             }
             rowData.push(value ?? null);

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -15,8 +15,13 @@ const sheetName = /[^\w\s-]/gi;
 const tableNameRegex = /[^\w]/gi
 const defaultFileType = reportTypes?.excel;
 const inputFormats = [
+    'MM/DD/YYYY hh:mm:ss A',
+    'MM/DD/YYYY HH:mm:ss A',
+    'MM/DD/YYYY HH:mm:ss',
+    'MM/DD/YYYY',
     'DD-MM-YYYY hh:mm:ss A',
     'DD-MM-YYYY HH:mm:ss',
+    'DD-MM-YYYY',
     'YYYY-MM-DD',
     'YYYY-MM-DD HH:mm:ss',
     'YYYY-MM-DDTHH:mm:ss',

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -89,7 +89,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             if (Object.keys(others).length > 0) {
                 if (['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'].includes(others.valueType)) {
                     others.numFmt = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
-                    rowsWithDateFields[others.valueType === 'localDateTime' ? others.field : others.name] = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
+                    rowsWithDateFields[others.valueType === 'localDateTime' ? (others.field || others.name) : others.name] = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
                 }
                 colFormats.push({ ...others, index });
             }

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -17,6 +17,7 @@ const defaultFileType = reportTypes?.excel;
 const inputFormats = [
     'DD-MM-YYYY hh:mm:ss A',
     'DD-MM-YYYY HH:mm:ss',
+    'YYYY-MM-DD',
     'YYYY-MM-DD HH:mm:ss',
     'YYYY-MM-DDTHH:mm:ss',
     'YYYY-MM-DDTHH:mm:ss.SSS[Z]',

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -105,7 +105,7 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
                     const format = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelExportFormat;
                     const rowFormat = others.valueType === 'date' ? userDateFormat : userDateFormat + dateTimeExcelRowExportFormat;
                     others.numFmt = format;
-                    rowsWithDateFields[key] = { format: rowFormat, localize: others.localize === true };
+                    rowsWithDateFields[key] = { format: rowFormat, parseAsUTC: others.localize === true };
                 }
                 colFormats.push({ ...others, index });
             }
@@ -120,8 +120,8 @@ const writeExcelSheet = function ({ title = "main", rows, columns, name, workboo
             let value = row[key];
             const dateConfig = rowsWithDateFields[key];
             if (dateConfig && value) {
-                const { format: outputFormat, localize } = dateConfig;
-                const parsed = localize ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
+                const { format: outputFormat, parseAsUTC } = dateConfig;
+                const parsed = parseAsUTC ? dayjs.utc(value, inputFormats, true) : dayjs(value, inputFormats, true);
                 value = parsed.isValid() ? parsed.format(outputFormat) : value;
             }
             rowData.push(value ?? null);

--- a/lib/reports.mjs
+++ b/lib/reports.mjs
@@ -9,7 +9,6 @@ import util from './util.js';
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 
-console.log('customParseFormat -> ', customParseFormat);
 const { reportDatesFormat, reportTypes, dateTimeExcelExportFormat, dateTimeExcelRowExportFormat } = util;
 
 const sheetName = /[^\w\s-]/gi;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -516,7 +516,7 @@ class Sql {
      * param5: { value: "test", sqlType: this.dataTypes.string, ignoreNull: false }
      * "SmartDevice.DeviceId": { value: "test", sqlType: this.dataTypes.string, ignoreNull: false }
      * param10: { fieldName: "SmartDevice.DeviceId", value: "test", sqlType: this.dataTypes.string, ignoreNull: false }
-     * param11: { value: "2024-01-15", type: "date" } // type can be "date", "dateTime", "dateTimeLocal", "datetime" - infers sqlType and skips UPPER() for forceCaseInsensitive
+     * param11: { value: "2024-01-15", type: "date" } // type can be "date", "dateTime" - infers sqlType and skips UPPER() for forceCaseInsensitive
      * }
      * @returns {String} - updated sql query
      */

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,13 @@ import stream from 'stream';
 import fs from 'fs';
 import prompt from 'prompt';
 import { Buffer } from 'buffer';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import config from './appConfig.mjs';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const macRegex = /([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/
 
@@ -488,18 +494,40 @@ export default {
             ? sqlType.type
             : sqlType;
     },
-    dateTimeInputFormats: [
-        'MM/DD/YYYY hh:mm:ss A',
-        'MM/DD/YYYY HH:mm:ss A',
-        'MM/DD/YYYY HH:mm:ss',
-        'MM/DD/YYYY',
-        'DD-MM-YYYY hh:mm:ss A',
-        'DD-MM-YYYY HH:mm:ss',
-        'DD-MM-YYYY',
-        'YYYY-MM-DD',
-        'YYYY-MM-DD HH:mm:ss',
-        'YYYY-MM-DDTHH:mm:ss',
-        'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
-        'YYYY-MM-DDTHH:mm:ss[Z]'
-    ]
+    /**
+     * Transforms a date/time value based on localization and formatting settings.
+     * 
+     * @param {Object} params
+     * @param {*} params.value - The date/time value to transform.
+     * @param {string} [params.valueType='dateTime'] - 'date' or 'dateTime'.
+     * @param {string} params.userDateFormat - Base date format.
+     * @param {string} params.userDateTimeFormat - Base date-time format.
+     * @param {string} [params.userTimezone] - User's timezone (e.g., 'America/New_York').
+     * @param {boolean} [params.localize=false] - Whether to apply localization.
+     * @returns {string} Formatted date/time string.
+     */
+    transformDateTime: function ({ value, valueType = 'dateTime', userDateFormat, userDateTimeFormat, userTimezone, localize = false }) {
+        if (!value) return '';
+
+        const format = valueType === 'date' ? (userDateFormat || this.reportDatesFormat[valueType]) : (userDateTimeFormat || this.reportDatesFormat[valueType]);
+        const langL = 'en';
+
+        let d = dayjs(value);
+
+        if (localize) {
+            d = d.utc();
+        }
+
+        if (userTimezone && localize) {
+            d = d.tz(userTimezone);
+        }
+
+        if (localize) {
+            value = d.utc().locale(langL).format(format);
+        } else {
+            value = d.locale(langL).format(format);
+        }
+
+        return value;
+    }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -507,7 +507,7 @@ export default {
      * @returns {string} Formatted date/time string.
      */
     transformDateTime: function ({ value, valueType = 'dateTime', userDateFormat, userDateTimeFormat, userTimezone, localize = false }) {
-        if (!value) return '';
+        if (value === null || value === undefined || value === '') return '';
 
         const format = valueType === 'date' ? (userDateFormat || this.reportDatesFormat[valueType]) : (userDateTimeFormat || this.reportDatesFormat[valueType]);
         const langL = 'en';

--- a/lib/util.js
+++ b/lib/util.js
@@ -362,7 +362,7 @@ export default {
         }
         return selectedDays.join(', ');
     },
-    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal'],
+    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'],
     dateTimeExportFormat: ' hh:mm:ss A',
     excelColumnWidthEnum: 6,
     dateTimeCSVExportFormat: '-hh:mm:ss A',

--- a/lib/util.js
+++ b/lib/util.js
@@ -512,21 +512,15 @@ export default {
         const format = valueType === 'date' ? (userDateFormat || this.reportDatesFormat[valueType]) : (userDateTimeFormat || this.reportDatesFormat[valueType]);
         const langL = 'en';
 
-        let d = dayjs(value);
+        // Parse as UTC for DB values when localizing; otherwise keep machine-local parsing
+        let d = localize ? dayjs.utc(value) : dayjs(value);
 
-        if (localize) {
-            d = d.utc();
-        }
-
-        if (userTimezone && localize) {
+        // Apply IANA timezone when provided and localization is requested
+        if (localize && userTimezone) {
             d = d.tz(userTimezone);
         }
 
-        if (localize) {
-            value = d.utc().locale(langL).format(format);
-        } else {
-            value = d.locale(langL).format(format);
-        }
+        value = d.locale(langL).format(format);
 
         return value;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -362,7 +362,7 @@ export default {
         }
         return selectedDays.join(', ');
     },
-    dateTimeFields: ['date', 'datetime', 'dateTime', 'dateTimeLocal', 'localDateTime'],
+    dateTimeFields: ['date', 'dateTime'],
     dateTimeExportFormat: ' hh:mm:ss A',
     excelColumnWidthEnum: 6,
     dateTimeCSVExportFormat: '-hh:mm:ss A',

--- a/lib/util.js
+++ b/lib/util.js
@@ -515,16 +515,12 @@ export default {
         // Parse as UTC for DB values when localizing; otherwise keep machine-local parsing
         let d = localize ? dayjs.utc(value) : dayjs(value);
 
-        // Apply IANA timezone when provided and localization is requested
-        if (localize && userTimezone) {
-            d = d.tz(userTimezone);
+        if (localize) {
+            // Convert to user's IANA timezone if provided, otherwise convert to local timezone
+            d = userTimezone ? d.tz(userTimezone) : d.local();
         }
 
-        if (localize) {
-            value = d.utc().locale(langL).format(format);
-        } else {
-            value = d.locale(langL).format(format);
-        }
+        value = d.locale(langL).format(format);
 
         return value;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -520,7 +520,11 @@ export default {
             d = d.tz(userTimezone);
         }
 
-        value = d.locale(langL).format(format);
+        if (localize) {
+            value = d.utc().locale(langL).format(format);
+        } else {
+            value = d.locale(langL).format(format);
+        }
 
         return value;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -487,5 +487,19 @@ export default {
         return typeof sqlType === 'object' && sqlType.type
             ? sqlType.type
             : sqlType;
-    }
+    },
+    dateTimeInputFormats: [
+        'MM/DD/YYYY hh:mm:ss A',
+        'MM/DD/YYYY HH:mm:ss A',
+        'MM/DD/YYYY HH:mm:ss',
+        'MM/DD/YYYY',
+        'DD-MM-YYYY hh:mm:ss A',
+        'DD-MM-YYYY HH:mm:ss',
+        'DD-MM-YYYY',
+        'YYYY-MM-DD',
+        'YYYY-MM-DD HH:mm:ss',
+        'YYYY-MM-DDTHH:mm:ss',
+        'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+        'YYYY-MM-DDTHH:mm:ss[Z]'
+    ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.67",
+  "version": "3.0.0",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/tests/where-type.test.js
+++ b/tests/where-type.test.js
@@ -141,7 +141,7 @@ console.log('\nTest 8: Without forceCaseInsensitive, date type has no effect on 
     test('Query does NOT contain UPPER(createdDate)', !result.includes('UPPER(createdDate)'), result);
 }
 
-// Test 9: With type="dateTime" (lowercase) also skips UPPER()
+// Test 9: With type="dateTime" also skips UPPER()
 console.log('\nTest 9: Date string with type="dateTime" skips UPPER() with forceCaseInsensitive');
 {
     const sql = new Sql();

--- a/tests/where-type.test.js
+++ b/tests/where-type.test.js
@@ -83,22 +83,6 @@ console.log('\nTest 3: Date string with type="dateTime" skips UPPER() with force
     test('Parameter value is NOT uppercased', request.parameters['createdDate'].value === '2024-01-15 00:00:00', JSON.stringify(request.parameters));
 }
 
-// Test 4: With forceCaseInsensitive=true, type="dateTimeLocal" also skips UPPER()
-console.log('\nTest 4: Date string with type="dateTimeLocal" skips UPPER() with forceCaseInsensitive');
-{
-    const sql = new Sql();
-    sql.forceCaseInsensitive = true;
-    const request = createMockRequest();
-    const result = sql.addParameters({
-        query: 'SELECT 1',
-        request,
-        parameters: { createdDate: { value: '2024-01-15T00:00:00', type: 'dateTimeLocal' } },
-        forWhere: true
-    });
-    test('Query does NOT contain UPPER(createdDate)', !result.includes('UPPER(createdDate)'), result);
-    test('Parameter value is NOT uppercased', request.parameters['createdDate'].value === '2024-01-15T00:00:00', JSON.stringify(request.parameters));
-}
-
 // Test 5: With type="date", sqlType is inferred as DateTime2 when not explicitly set
 console.log('\nTest 5: sqlType is inferred as DateTime2 when type="date"');
 {
@@ -157,8 +141,8 @@ console.log('\nTest 8: Without forceCaseInsensitive, date type has no effect on 
     test('Query does NOT contain UPPER(createdDate)', !result.includes('UPPER(createdDate)'), result);
 }
 
-// Test 9: With type="datetime" (lowercase) also skips UPPER()
-console.log('\nTest 9: Date string with type="datetime" skips UPPER() with forceCaseInsensitive');
+// Test 9: With type="dateTime" (lowercase) also skips UPPER()
+console.log('\nTest 9: Date string with type="dateTime" skips UPPER() with forceCaseInsensitive');
 {
     const sql = new Sql();
     sql.forceCaseInsensitive = true;
@@ -166,7 +150,7 @@ console.log('\nTest 9: Date string with type="datetime" skips UPPER() with force
     const result = sql.addParameters({
         query: 'SELECT 1',
         request,
-        parameters: { createdDate: { value: '2024-01-15', type: 'datetime' } },
+        parameters: { createdDate: { value: '2024-01-15', type: 'dateTime' } },
         forWhere: true
     });
     test('Query does NOT contain UPPER(createdDate)', !result.includes('UPPER(createdDate)'), result);


### PR DESCRIPTION
`writeExcelSheet` uses strict dayjs parsing (`customParseFormat`) but `inputFormats` was missing the `MM/DD/YYYY` family — the exact formats that `updateKeys()` emits before rows reach the Excel writer. This caused all pre-formatted date values to silently fall back to the raw string instead of being re-formatted with the correct Excel cell format.

Separately, the `toExcel()` call site was passing `userDateTimeFormat`, `lookups`, and `lookupFields` which `toExcel`/`writeExcelSheet` never accepted, making the callsite misleading.

## `lib/reports.mjs`
- Added missing formats to `inputFormats`:
  - `MM/DD/YYYY` (date-only)
  - `MM/DD/YYYY hh:mm:ss A` — matches `userDateFormat + dateTimeExcelRowExportFormat`
  - `MM/DD/YYYY HH:mm:ss A` — matches `reportDatesFormat.dateTime`
  - `MM/DD/YYYY HH:mm:ss`
  - `DD-MM-YYYY` (date-only variant of the existing `DD-MM-YYYY HH:mm:ss` entry)

## `lib/middleware/response-transformer.mjs`
- Removed unused args from `toExcel()` call:
  ```js
  // before
  toExcel({ sheets, stream: res, exportColumns: true, userDateFormat, userDateTimeFormat: dateTimeFormat, lookups, lookupFields })
  // after
  toExcel({ sheets, stream: res, exportColumns: true, userDateFormat })
  ```