### PR TITLE
#68332- add logical operator support to WHERE clauses

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -957,15 +957,16 @@ class Sql {
         
         // Add JOIN clauses before WHERE clause
         if (joinClauses.length > 0) {
+            let joinsInserted = false;
             if (appendAnd) {
                 // Query already has a WHERE; insert JOINs before it to produce valid SQL.
                 const whereMatch = query.search(/\bWHERE\b/i);
                 if (whereMatch !== -1) {
                     query = query.slice(0, whereMatch).trimEnd() + ' ' + joinClauses.join(' ') + ' ' + query.slice(whereMatch);
-                } else {
-                    query += " " + joinClauses.join(' ');
+                    joinsInserted = true;
                 }
-            } else {
+            }
+            if (!joinsInserted) {
                 query += " " + joinClauses.join(' ');
             }
         }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -807,7 +807,7 @@ class Sql {
      *   a WHERE clause — use this for INSERT/UPDATE column values or stored-procedure arguments.
      * @returns {String} - updated sql query
      */
-    addParameters({ query, request, parameters, forWhere = false }) {
+    addParameters({ query, request, parameters, forWhere = false, logicalOperator = 'AND', appendAnd = false }) {
         if (!parameters) {
             return query;
         }
@@ -952,7 +952,15 @@ class Sql {
         }
         
         if (whereClauses.length > 0) {
-            query += " WHERE " + whereClauses.join(' AND ');
+            //appendAnd is true when we are adding to an existing where clause, so we need to use AND to connect them. Otherwise, we start a new where clause.
+            const prefix = appendAnd ? ' AND ' : ' WHERE ';
+            const op = logicalOperator.toUpperCase();
+            // Wrap OR groups in parens so they cannot weaken system conditions:
+            //   WHERE IsDeleted=0 AND ClientId IN (…) AND (filter1 OR filter2)
+            const clauseStr = (op === 'OR' && whereClauses.length > 1)
+                ? `(${whereClauses.join(' OR ')})`
+                : whereClauses.join(` ${op} `);
+            query += prefix + clauseStr;
         }
         return query;
     }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -9,6 +9,8 @@ const { maxQueryTime = 500 } = config || {};
 const { inOperatorStrategies, dateTimeFields, columnTypes } = enums;
 
 const isNullNotNullOperators = ['IS NOT NULL', 'IS NULL'];
+const whereClauseRegex = /\bWHERE\b/i;
+const appendAndBoundaryRegex = /\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/i;
 
 const createQueryLogger = function ({ queryLogThreshold, timeoutLogLevel, logger }) {
     return async function ({ query, start, end = Date.now(), parameters }) {
@@ -814,6 +816,8 @@ class Sql {
      *   Use this to extend an existing query with additional filter conditions. When false (default),
      *   a new WHERE keyword is prepended to the conditions. Interacts with `forWhere`: `appendAnd`
      *   only affects the WHERE/AND prefix; `forWhere` must still be true for conditions to be built.
+     *   Throws if no WHERE exists, and inserts the new conditions before ORDER BY / GROUP BY /
+     *   HAVING / OFFSET / FETCH (and before a trailing semicolon) when those clauses are present.
      * @returns {String} - updated sql query
      */
     addParameters({ query, request, parameters, forWhere = false, logicalOperator = 'AND', appendAnd = false }) {
@@ -955,16 +959,18 @@ class Sql {
             }
         }
         
+        const appendAndWhereIndex = appendAnd ? query.search(whereClauseRegex) : -1;
+        if (appendAnd && appendAndWhereIndex === -1) {
+            throw new Error('appendAnd requires an existing WHERE clause in the query.');
+        }
+        
         // Add JOIN clauses before WHERE clause
         if (joinClauses.length > 0) {
             let joinsInserted = false;
             if (appendAnd) {
                 // Query already has a WHERE; insert JOINs before it to produce valid SQL.
-                const whereMatch = query.search(/\bWHERE\b/i);
-                if (whereMatch !== -1) {
-                    query = query.slice(0, whereMatch).trimEnd() + ' ' + joinClauses.join(' ') + ' ' + query.slice(whereMatch);
-                    joinsInserted = true;
-                }
+                query = query.slice(0, appendAndWhereIndex).trimEnd() + ' ' + joinClauses.join(' ') + ' ' + query.slice(appendAndWhereIndex);
+                joinsInserted = true;
             }
             if (!joinsInserted) {
                 query += " " + joinClauses.join(' ');
@@ -986,7 +992,16 @@ class Sql {
             const clauseStr = (op === 'OR' && whereClauses.length > 1)
                 ? `(${whereClauses.join(' OR ')})`
                 : whereClauses.join(` ${op} `);
-            query += prefix + clauseStr;
+            if (appendAnd) {
+                const trimmedQuery = query.replace(/;\s*$/, '');
+                const boundaryMatch = appendAndBoundaryRegex.exec(trimmedQuery.slice(appendAndWhereIndex));
+                const insertIndex = boundaryMatch ? appendAndWhereIndex + boundaryMatch.index : trimmedQuery.length;
+                const suffix = query.slice(insertIndex);
+                const separator = suffix && !/^[\s;]/.test(suffix) ? ' ' : '';
+                query = query.slice(0, insertIndex).trimEnd() + prefix + clauseStr + separator + suffix;
+            } else {
+                query += prefix + clauseStr;
+            }
         }
         return query;
     }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -805,6 +805,15 @@ class Sql {
      * @param {boolean} [options.forWhere=false] - When true, generates WHERE clause conditions from
      *   the parameters. When false (default), parameters are bound to the request without building
      *   a WHERE clause — use this for INSERT/UPDATE column values or stored-procedure arguments.
+     * @param {'AND'|'OR'} [options.logicalOperator='AND'] - Logical operator used to join WHERE
+     *   clause conditions. Must be 'AND' or 'OR' (case-insensitive). When 'OR' and multiple
+     *   conditions exist, the group is wrapped in parentheses so it cannot weaken outer filters
+     *   (e.g. `WHERE IsDeleted=0 AND (filter1 OR filter2)`). Throws on any other value or null.
+     * @param {boolean} [options.appendAnd=false] - When true, assumes the query already contains
+     *   a WHERE clause and joins the new conditions with AND instead of adding a new WHERE keyword.
+     *   Use this to extend an existing query with additional filter conditions. When false (default),
+     *   a new WHERE keyword is prepended to the conditions. Interacts with `forWhere`: `appendAnd`
+     *   only affects the WHERE/AND prefix; `forWhere` must still be true for conditions to be built.
      * @returns {String} - updated sql query
      */
     addParameters({ query, request, parameters, forWhere = false, logicalOperator = 'AND', appendAnd = false }) {
@@ -948,13 +957,29 @@ class Sql {
         
         // Add JOIN clauses before WHERE clause
         if (joinClauses.length > 0) {
-            query += " " + joinClauses.join(' ');
+            if (appendAnd) {
+                // Query already has a WHERE; insert JOINs before it to produce valid SQL.
+                const whereMatch = query.search(/\bWHERE\b/i);
+                if (whereMatch !== -1) {
+                    query = query.slice(0, whereMatch).trimEnd() + ' ' + joinClauses.join(' ') + ' ' + query.slice(whereMatch);
+                } else {
+                    query += " " + joinClauses.join(' ');
+                }
+            } else {
+                query += " " + joinClauses.join(' ');
+            }
         }
         
         if (whereClauses.length > 0) {
             //appendAnd is true when we are adding to an existing where clause, so we need to use AND to connect them. Otherwise, we start a new where clause.
             const prefix = appendAnd ? ' AND ' : ' WHERE ';
+            if (!logicalOperator || typeof logicalOperator !== 'string') {
+                throw new Error(`Invalid logicalOperator "${logicalOperator}": must be 'AND' or 'OR'.`);
+            }
             const op = logicalOperator.toUpperCase();
+            if (op !== 'AND' && op !== 'OR') {
+                throw new Error(`Invalid logicalOperator "${logicalOperator}": must be 'AND' or 'OR'.`);
+            }
             // Wrap OR groups in parens so they cannot weaken system conditions:
             //   WHERE IsDeleted=0 AND ClientId IN (…) AND (filter1 OR filter2)
             const clauseStr = (op === 'OR' && whereClauses.length > 1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/tests/logical-operator.test.js
+++ b/tests/logical-operator.test.js
@@ -1,0 +1,180 @@
+/**
+ * Tests for addParameters logicalOperator and appendAnd options.
+ * Covers: OR grouping with parentheses, AND default, appendAnd mode, and
+ * invalid logicalOperator rejection.
+ */
+
+import Sql from '../lib/sql.js';
+
+function createMockRequest() {
+    return {
+        parameters: {},
+        input: function(name, typeOrValue, value) {
+            if (arguments.length === 2) {
+                this.parameters[name] = { value: typeOrValue };
+            } else {
+                this.parameters[name] = { type: typeOrValue, value: value };
+            }
+        }
+    };
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, condition, extra = '') {
+    if (condition) {
+        console.log(`✓ ${name}`);
+        passed++;
+    } else {
+        console.log(`✗ ${name}${extra ? ': ' + extra : ''}`);
+        failed++;
+    }
+}
+
+console.log('Testing logicalOperator and appendAnd options...\n');
+
+// Test 1: Default (AND) — multiple conditions joined with AND, no parentheses
+console.log('Test 1: Default AND joins conditions without parentheses');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T',
+        request,
+        parameters: { a: { value: 1 }, b: { value: 2 } },
+        forWhere: true
+    });
+    test('Query contains WHERE', result.includes('WHERE'), result);
+    test('Conditions joined with AND', result.includes(' AND '), result);
+    test('No parentheses around conditions', !result.includes('(a') && !result.includes('(b'), result);
+}
+
+// Test 2: logicalOperator='OR' with multiple conditions — wrapped in parentheses
+console.log('\nTest 2: OR with multiple conditions wraps group in parentheses');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T',
+        request,
+        parameters: { a: { value: 1 }, b: { value: 2 } },
+        forWhere: true,
+        logicalOperator: 'OR'
+    });
+    test('Query contains WHERE', result.includes('WHERE'), result);
+    test('Conditions wrapped in parentheses', result.includes('('), result);
+    test('Conditions joined with OR', result.includes(' OR '), result);
+    test('Opening paren precedes first condition', /WHERE \(/.test(result), result);
+}
+
+// Test 3: logicalOperator='OR' with a single condition — no parentheses needed
+console.log('\nTest 3: OR with single condition does not add extra parentheses');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T',
+        request,
+        parameters: { a: { value: 1 } },
+        forWhere: true,
+        logicalOperator: 'OR'
+    });
+    test('Query contains WHERE', result.includes('WHERE'), result);
+    test('Single condition has no wrapping parens', !/WHERE \(/.test(result), result);
+}
+
+// Test 4: appendAnd=true — uses AND instead of WHERE
+console.log('\nTest 4: appendAnd=true appends AND instead of WHERE');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T WHERE IsDeleted = 0',
+        request,
+        parameters: { a: { value: 1 } },
+        forWhere: true,
+        appendAnd: true
+    });
+    test('Query does not add a second WHERE', (result.match(/\bWHERE\b/g) || []).length === 1, result);
+    test('New condition joined with AND', / AND a =/.test(result), result);
+}
+
+// Test 5: appendAnd=true with OR — OR group still wrapped in parens
+console.log('\nTest 5: appendAnd=true with OR wraps group in parentheses');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T WHERE IsDeleted = 0',
+        request,
+        parameters: { a: { value: 1 }, b: { value: 2 } },
+        forWhere: true,
+        logicalOperator: 'OR',
+        appendAnd: true
+    });
+    test('Only one WHERE keyword', (result.match(/\bWHERE\b/g) || []).length === 1, result);
+    test('OR group wrapped in parens and joined with AND', / AND \(/.test(result), result);
+    test('Conditions joined with OR inside parens', result.includes(' OR '), result);
+}
+
+// Test 6: null logicalOperator throws
+console.log('\nTest 6: null logicalOperator throws an error');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    let threw = false;
+    try {
+        sql.addParameters({
+            query: 'SELECT 1 FROM T',
+            request,
+            parameters: { a: { value: 1 } },
+            forWhere: true,
+            logicalOperator: null
+        });
+    } catch (e) {
+        threw = true;
+    }
+    test('Throws for null logicalOperator', threw);
+}
+
+// Test 7: invalid logicalOperator throws
+console.log('\nTest 7: invalid logicalOperator throws an error');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    let threw = false;
+    let errMsg = '';
+    try {
+        sql.addParameters({
+            query: 'SELECT 1 FROM T',
+            request,
+            parameters: { a: { value: 1 } },
+            forWhere: true,
+            logicalOperator: 'OR 1=1; --'
+        });
+    } catch (e) {
+        threw = true;
+        errMsg = e.message;
+    }
+    test('Throws for invalid logicalOperator', threw, errMsg);
+    test('Error message mentions the invalid value', errMsg.includes('OR 1=1; --'), errMsg);
+}
+
+// Test 8: case-insensitive logicalOperator ('or' / 'and')
+console.log('\nTest 8: logicalOperator is case-insensitive');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T',
+        request,
+        parameters: { a: { value: 1 }, b: { value: 2 } },
+        forWhere: true,
+        logicalOperator: 'or'
+    });
+    test('Lowercase "or" is accepted', result.includes(' OR '), result);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/logical-operator.test.js
+++ b/tests/logical-operator.test.js
@@ -22,6 +22,8 @@ function createMockRequest() {
 let passed = 0;
 let failed = 0;
 
+const WHERE_PATTERN = /\bWHERE\b/g;
+
 function test(name, condition, extra = '') {
     if (condition) {
         console.log(`✓ ${name}`);
@@ -96,7 +98,7 @@ console.log('\nTest 4: appendAnd=true appends AND instead of WHERE');
         forWhere: true,
         appendAnd: true
     });
-    test('Query does not add a second WHERE', (result.match(/\bWHERE\b/g) || []).length === 1, result);
+    test('Query does not add a second WHERE', (result.match(WHERE_PATTERN) || []).length === 1, result);
     test('New condition joined with AND', / AND a =/.test(result), result);
 }
 
@@ -113,7 +115,7 @@ console.log('\nTest 5: appendAnd=true with OR wraps group in parentheses');
         logicalOperator: 'OR',
         appendAnd: true
     });
-    test('Only one WHERE keyword', (result.match(/\bWHERE\b/g) || []).length === 1, result);
+    test('Only one WHERE keyword', (result.match(WHERE_PATTERN) || []).length === 1, result);
     test('OR group wrapped in parens and joined with AND', / AND \(/.test(result), result);
     test('Conditions joined with OR inside parens', result.includes(' OR '), result);
 }

--- a/tests/logical-operator.test.js
+++ b/tests/logical-operator.test.js
@@ -178,5 +178,74 @@ console.log('\nTest 8: logicalOperator is case-insensitive');
     test('Lowercase "or" is accepted', result.includes(' OR '), result);
 }
 
+// Test 9: appendAnd=true inserts before ORDER BY and trailing semicolon
+console.log('\nTest 9: appendAnd=true inserts before ORDER BY and trailing semicolon');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T WHERE IsDeleted = 0 ORDER BY Name;',
+        request,
+        parameters: { a: { value: 1 } },
+        forWhere: true,
+        appendAnd: true
+    });
+    test('Condition is inserted before ORDER BY', result.includes('WHERE IsDeleted = 0 AND a = @a ORDER BY Name'), result);
+    test('Trailing semicolon is preserved', result.endsWith('ORDER BY Name;'), result);
+}
+
+// Test 10: appendAnd=true inserts before GROUP BY / HAVING
+console.log('\nTest 10: appendAnd=true inserts before GROUP BY / HAVING');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT Type, COUNT(*) FROM T WHERE IsDeleted = 0 GROUP BY Type HAVING COUNT(*) > 1',
+        request,
+        parameters: { a: { value: 1 } },
+        forWhere: true,
+        appendAnd: true
+    });
+    test('Condition is inserted before GROUP BY', result.includes('WHERE IsDeleted = 0 AND a = @a GROUP BY Type HAVING COUNT(*) > 1'), result);
+}
+
+// Test 11: appendAnd=true inserts before OFFSET / FETCH
+console.log('\nTest 11: appendAnd=true inserts before OFFSET / FETCH');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    const result = sql.addParameters({
+        query: 'SELECT 1 FROM T WHERE IsDeleted = 0 OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY',
+        request,
+        parameters: { a: { value: 1 } },
+        forWhere: true,
+        appendAnd: true
+    });
+    test('Condition is inserted before OFFSET', result.includes('WHERE IsDeleted = 0 AND a = @a OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY'), result);
+}
+
+// Test 12: appendAnd=true without an existing WHERE throws
+console.log('\nTest 12: appendAnd=true without WHERE throws an error');
+{
+    const sql = new Sql();
+    const request = createMockRequest();
+    let threw = false;
+    let errMsg = '';
+    try {
+        sql.addParameters({
+            query: 'SELECT 1 FROM T',
+            request,
+            parameters: { a: { value: 1 } },
+            forWhere: true,
+            appendAnd: true
+        });
+    } catch (e) {
+        threw = true;
+        errMsg = e.message;
+    }
+    test('Throws when appendAnd query has no WHERE', threw, errMsg);
+    test('Error message mentions existing WHERE clause', errMsg.includes('existing WHERE clause'), errMsg);
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
Enhanced addParameters method to support custom logical operators (AND/OR) and appending to existing WHERE clauses. Added appendAnd parameter to distinguish between starting a new WHERE clause and appending to an existing one. Implemented parentheses wrapping for OR groups to prevent them from weakening system conditions like deletion flags or client filters.

Co-authored-by: Copilot <copilot@github.com>