### PR TITLE
#78332: detect outermost WHERE clause in nested queries

### DIFF
--- a/lib/sql.js
+++ b/lib/sql.js
@@ -959,7 +959,20 @@ class Sql {
             }
         }
         
-        const appendAndWhereIndex = appendAnd ? query.search(whereClauseRegex) : -1;
+        // Find the outermost WHERE (depth 0, not inside parentheses) so that
+        // queries wrapping a subquery with its own WHERE/ORDER BY clauses don't
+        // get column-filter conditions injected inside the inner subquery.
+        const appendAndWhereIndex = appendAnd ? (() => {
+            let depth = 0;
+            const tokenRegex = /\(|\)|\bWHERE\b/gi;
+            let match;
+            while ((match = tokenRegex.exec(query)) !== null) {
+                if (match[0] === '(') depth++;
+                else if (match[0] === ')') depth--;
+                else if (depth === 0) return match.index;
+            }
+            return -1;
+        })() : -1;
         if (appendAnd && appendAndWhereIndex === -1) {
             throw new Error('appendAnd requires an existing WHERE clause in the query.');
         }

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -1007,8 +1007,18 @@ class Sql {
                 : whereClauses.join(` ${op} `);
             if (appendAnd) {
                 const trimmedQuery = query.replace(/;\s*$/, '');
-                const boundaryMatch = appendAndBoundaryRegex.exec(trimmedQuery.slice(appendAndWhereIndex));
-                const insertIndex = boundaryMatch ? appendAndWhereIndex + boundaryMatch.index : trimmedQuery.length;
+                const insertIndex = (() => {
+                    let depth = 0;
+                    const tokenRegex = /\(|\)|\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/gi;
+                    tokenRegex.lastIndex = appendAndWhereIndex;
+                    let match;
+                    while ((match = tokenRegex.exec(trimmedQuery)) !== null) {
+                        if (match[0] === '(') depth++;
+                        else if (match[0] === ')') depth--;
+                        else if (depth === 0) return match.index;
+                    }
+                    return trimmedQuery.length;
+                })();
                 const suffix = query.slice(insertIndex);
                 const separator = suffix && !/^[\s;]/.test(suffix) ? ' ' : '';
                 query = query.slice(0, insertIndex).trimEnd() + prefix + clauseStr + separator + suffix;

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -114,6 +114,27 @@ class Sql {
     }
 
     /**
+     * Finds the first match of a token pattern at depth 0 (outermost level),
+     * accounting for nested parentheses. Used for depth-aware SQL token scanning.
+     * @param {string} text - The text to search in
+     * @param {RegExp} tokenPattern - The regex pattern to match
+     * @param {number} startIndex - The index to start searching from (default: 0)
+     * @returns {number} The index of the first match at depth 0, or -1 if not found
+     */
+    findOutermostToken(text, tokenPattern, startIndex = 0) {
+        let depth = 0;
+        const combinedRegex = new RegExp(`\\(|\\)|${tokenPattern.source}`, 'gi');
+        combinedRegex.lastIndex = startIndex;
+        let match;
+        while ((match = combinedRegex.exec(text)) !== null) {
+            if (match[0] === '(') depth++;
+            else if (match[0] === ')') depth--;
+            else if (depth === 0) return match.index;
+        }
+        return -1;
+    }
+
+    /**
      * Gets the next unique TVP alias to avoid table name conflicts
      * @returns {string} Unique alias like "_tvp1", "_tvp2", etc.
      */
@@ -959,25 +980,10 @@ class Sql {
             }
         }
 
-        // Helper: find the first match of tokenPattern at depth 0 (outermost level)
-        // starting from startIndex, accounting for nested parentheses.
-        const findOutermostToken = (text, tokenPattern, startIndex = 0) => {
-            let depth = 0;
-            const combinedRegex = new RegExp(`\\(|\\)|${tokenPattern.source}`, 'gi');
-            combinedRegex.lastIndex = startIndex;
-            let match;
-            while ((match = combinedRegex.exec(text)) !== null) {
-                if (match[0] === '(') depth++;
-                else if (match[0] === ')') depth--;
-                else if (depth === 0) return match.index;
-            }
-            return -1;
-        };
-
         // Find the outermost WHERE (depth 0, not inside parentheses) so that
         // queries wrapping a subquery with its own WHERE/ORDER BY clauses don't
         // get column-filter conditions injected inside the inner subquery.
-        const appendAndWhereIndex = appendAnd ? findOutermostToken(query, /\bWHERE\b/i) : -1;
+        const appendAndWhereIndex = appendAnd ? this.findOutermostToken(query, /\bWHERE\b/i) : -1;
         if (appendAnd && appendAndWhereIndex === -1) {
             throw new Error('appendAnd requires an existing WHERE clause in the query.');
         }
@@ -1013,7 +1019,7 @@ class Sql {
             if (appendAnd) {
                 const trimmedQuery = query.replace(/;\s*$/, '');
                 // Find the outermost boundary (ORDER BY, GROUP BY, etc.) after the WHERE
-                const insertIndex = findOutermostToken(trimmedQuery, /\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/i, appendAndWhereIndex);
+                const insertIndex = this.findOutermostToken(trimmedQuery, /\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/i, appendAndWhereIndex);
                 const finalIndex = insertIndex === -1 ? trimmedQuery.length : insertIndex;
                 const suffix = query.slice(finalIndex);
                 const separator = suffix && !/^[\s;]/.test(suffix) ? ' ' : '';

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -958,25 +958,30 @@ class Sql {
                 whereClauses.push(statement);
             }
         }
-        
-        // Find the outermost WHERE (depth 0, not inside parentheses) so that
-        // queries wrapping a subquery with its own WHERE/ORDER BY clauses don't
-        // get column-filter conditions injected inside the inner subquery.
-        const appendAndWhereIndex = appendAnd ? (() => {
+
+        // Helper: find the first match of tokenPattern at depth 0 (outermost level)
+        // starting from startIndex, accounting for nested parentheses.
+        const findOutermostToken = (text, tokenPattern, startIndex = 0) => {
             let depth = 0;
-            const tokenRegex = /\(|\)|\bWHERE\b/gi;
+            const combinedRegex = new RegExp(`\\(|\\)|${tokenPattern.source}`, 'gi');
+            combinedRegex.lastIndex = startIndex;
             let match;
-            while ((match = tokenRegex.exec(query)) !== null) {
+            while ((match = combinedRegex.exec(text)) !== null) {
                 if (match[0] === '(') depth++;
                 else if (match[0] === ')') depth--;
                 else if (depth === 0) return match.index;
             }
             return -1;
-        })() : -1;
+        };
+
+        // Find the outermost WHERE (depth 0, not inside parentheses) so that
+        // queries wrapping a subquery with its own WHERE/ORDER BY clauses don't
+        // get column-filter conditions injected inside the inner subquery.
+        const appendAndWhereIndex = appendAnd ? findOutermostToken(query, /\bWHERE\b/i) : -1;
         if (appendAnd && appendAndWhereIndex === -1) {
             throw new Error('appendAnd requires an existing WHERE clause in the query.');
         }
-        
+
         // Add JOIN clauses before WHERE clause
         if (joinClauses.length > 0) {
             let joinsInserted = false;
@@ -989,7 +994,7 @@ class Sql {
                 query += " " + joinClauses.join(' ');
             }
         }
-        
+
         if (whereClauses.length > 0) {
             //appendAnd is true when we are adding to an existing where clause, so we need to use AND to connect them. Otherwise, we start a new where clause.
             const prefix = appendAnd ? ' AND ' : ' WHERE ';
@@ -1007,21 +1012,12 @@ class Sql {
                 : whereClauses.join(` ${op} `);
             if (appendAnd) {
                 const trimmedQuery = query.replace(/;\s*$/, '');
-                const insertIndex = (() => {
-                    let depth = 0;
-                    const tokenRegex = /\(|\)|\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/gi;
-                    tokenRegex.lastIndex = appendAndWhereIndex;
-                    let match;
-                    while ((match = tokenRegex.exec(trimmedQuery)) !== null) {
-                        if (match[0] === '(') depth++;
-                        else if (match[0] === ')') depth--;
-                        else if (depth === 0) return match.index;
-                    }
-                    return trimmedQuery.length;
-                })();
-                const suffix = query.slice(insertIndex);
+                // Find the outermost boundary (ORDER BY, GROUP BY, etc.) after the WHERE
+                const insertIndex = findOutermostToken(trimmedQuery, /\b(?:ORDER\s+BY|GROUP\s+BY|HAVING|OFFSET|FETCH)\b/i, appendAndWhereIndex);
+                const finalIndex = insertIndex === -1 ? trimmedQuery.length : insertIndex;
+                const suffix = query.slice(finalIndex);
                 const separator = suffix && !/^[\s;]/.test(suffix) ? ' ' : '';
-                query = query.slice(0, insertIndex).trimEnd() + prefix + clauseStr + separator + suffix;
+                query = query.slice(0, finalIndex).trimEnd() + prefix + clauseStr + separator + suffix;
             } else {
                 query += prefix + clauseStr;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Replace simple regex search with depth-aware algorithm to find the outermost WHERE clause. Tracks parentheses nesting depth to prevent column-filter conditions from being incorrectly injected into subqueries with their own WHERE/ORDER BY clauses.