### PR TITLE
#74833  - fix isEmpty and isNotEmpty operator values

### DIFF
--- a/lib/business/business-base.mjs
+++ b/lib/business/business-base.mjs
@@ -43,10 +43,10 @@ const compareLookups = {
         return { operator: '!=', value: v === '' ? null : v, type: type };
     },
     "isEmpty": function ({ type }) {
-        return { operator: 'IS', value: "isEmpty", type: type };
+        return { operator: 'IS', value: null, type: type };
     },
     "isNotEmpty": function ({ type }) {
-        return { operator: 'IS NOT', value: "isNotEmpty", type: type };
+        return { operator: 'IS NOT', value: null, type: type };
     },
     ">": function ({ v, type }) {
         return { operator: '>', value: v, type: type };

--- a/lib/sql.js
+++ b/lib/sql.js
@@ -967,7 +967,7 @@ class Sql {
                             continue; // Don't add to WHERE clause
                         }
                 }
-            } else {
+            } else if (!isNullNotNullOperators.includes(operator)) {
                 if (sqlType !== undefined && sqlType !== null) {
                     request.input(paramName, sqlType, value);
                 } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/tests/case-insensitive.test.js
+++ b/tests/case-insensitive.test.js
@@ -257,6 +257,23 @@ test("addParameters with forceCaseInsensitive: does not transform non-WHERE valu
     assert.equal(request.parameters['UserName'].value, 'john');
 });
 
+test("addParameters with IS NULL/IS NOT NULL: builds null checks without binding parameters", () => {
+    const sql = makeSql();
+    const request = createMockRequest();
+    const query = sql.addParameters({
+        query: 'SELECT 1',
+        request,
+        parameters: {
+            DeletedOn: { operator: 'IS NULL', value: null },
+            UpdatedOn: { operator: 'IS NOT NULL', value: null }
+        },
+        forWhere: true
+    });
+    assert.ok(query.includes('DeletedOn IS NULL'));
+    assert.ok(query.includes('UpdatedOn IS NOT NULL'));
+    assert.equal(Object.keys(request.parameters).length, 0);
+});
+
 // ---------------------------------------------------------------------------
 // setConfig picks up caseInsensitiveMode and shadowColumns
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Update isEmpty and isNotEmpty lookup operators to use null values instead of string literals for proper IS/IS NOT operator handling.

Add conditional guard in SQL generation to prevent processing null/not-null operators in incorrect context.