### PR TITLE
Bug #70477 Playbook / Portal (RawURL in error not showing Hash)

### DIFF
--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -51,7 +51,7 @@ const createWriteStream = function (options = {}) {
         }
 
         const { req = {}, ...others } = log;
-        const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...errorInfo } = others;
+        const { Username = "", time = new Date().toISOString(), hostname, pid, level, rawUrl, ...errorInfo } = others;
         const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
 
         // Build query params per line
@@ -61,7 +61,7 @@ const createWriteStream = function (options = {}) {
         queryParams.set("Remote Host", req.remoteAddress || "");
         queryParams.set("User Agent", req.userAgent || "");
         queryParams.set("Absolute Url", req.url || "");
-        queryParams.set("UrlReferrer", req.referrer || "");
+        queryParams.set("UrlReferrer", rawUrl || req.referrer || "");
         queryParams.set("Date/ Time (UTC)", time);
         queryParams.set("User", Username);
         queryParams.set("exception", JSON.stringify(errorInfo));


### PR DESCRIPTION
Destructuring rawUrl from the log object and preferring it over req.referrer when setting the UrlReferrer query param.