### PR TITLE
#75677 -  Add support for exception monitor params in dframework-node. Peer tested with Vishal Sir

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -97,6 +97,7 @@ if (otherConfig.httpConfig) {
         options: {
             method: 'post',
             retries: 0,
+            customLevels: hasCustomLevels ? customLevels : undefined,
             ...httpConfig
         }
     });

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -7,15 +7,18 @@ const MACHINE_NAME = os.hostname();
 const CWD = process.cwd();
 const H2_SESSION_CLOSE_TIMEOUT_MS = 300;
 
-// Convert nested objects into URLSearchParams-friendly strings
-const convertToURLSearchParams = (obj) => {
+// Standard pino level numbers -> label, used to render a human severity string
+const STANDARD_LEVEL_LABELS = { 10: "trace", 20: "debug", 30: "info", 40: "warn", 50: "error", 60: "fatal" };
+
+// Flatten a payload object into URLSearchParams, JSON-stringifying nested values
+const toURLSearchParams = (obj) => {
   const params = new URLSearchParams();
   Object.entries(obj || {}).forEach(([key, value]) => {
     typeof value === "object" && value !== null
       ? params.append(key, JSON.stringify(value))
       : params.append(key, value ?? "");
   });
-  return params.toString();
+  return params;
 };
 
 /**
@@ -24,11 +27,29 @@ const convertToURLSearchParams = (obj) => {
  * - url: string (required) Target endpoint
  * - http2: boolean (optional) If true and endpoint is https, use HTTP/2 client
  * - method: string (optional) HTTP method; defaults to "POST"
+ * - format: string (optional) "urlencoded" (default) or "json"; both send the same payload
+ *   fields (error, message, stackTrace, exceptionType, severity, occurredAt, source,
+ *   systemPath, environment, correlationId, userName, method, url, referrer, remoteHost,
+ *   userAgent, form, queryString, exception) and only differ in serialization
+ * - headers: object (optional) extra headers sent with every request
+ * - apiKey: string (optional) sent as the "X-Exception-Api-Key" header
+ * - environment: string (optional) reported in JSON format; defaults to NODE_ENV or "production"
+ * - customLevels: object (optional) name->number map used to render "severity" labels
  */
 const createWriteStream = function (options = {}) {
   const baseURL = new URL(options.url);
   const useHttp2 = options.http2 === true && baseURL.protocol === "https:";
   const method = (options.method || "POST").toUpperCase();
+  const format = (options.format || "urlencoded").toLowerCase();
+  const environment = options.environment || process.env.NODE_ENV || "production";
+  const levelLabels = { ...STANDARD_LEVEL_LABELS };
+  Object.entries(options.customLevels || {}).forEach(([name, value]) => {
+    levelLabels[value] = name;
+  });
+  const extraHeaders = {
+    ...(options.headers || {}),
+    ...({ "X-Exception-Api-Key": options.exceptionMonitorApiKey } || {}),
+  };
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)
   let h2Session = null;
@@ -52,28 +73,50 @@ const createWriteStream = function (options = {}) {
 
         const { req = {}, ...others } = log;
         const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...errorInfo } = others;
-        const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
 
-        // Build query params per line
-        const queryParams = new URLSearchParams();
-        queryParams.set("Machine Name", hostname || MACHINE_NAME);
-        queryParams.set("System Path", CWD);
-        queryParams.set("Remote Host", req.remoteAddress || "");
-        queryParams.set("User Agent", req.userAgent || "");
-        queryParams.set("Absolute Url", req.url || "");
-        queryParams.set("UrlReferrer", req.referrer || "");
-        queryParams.set("Date/ Time (UTC)", time);
-        queryParams.set("User", Username);
-        queryParams.set("exception", JSON.stringify(errorInfo));
-        queryParams.set("Form", convertToURLSearchParams(paramsObj));
-        queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
+        const err = errorInfo.err || {};
+        const payload = {
+          error: err.message || "",
+          message: errorInfo.query || errorInfo.msg || "",
+          stackTrace: err.stack || "",
+          exceptionType: err.type || "",
+          severity: levelLabels[level] || String(level ?? ""),
+          occurredAt: time,
+          source: hostname || MACHINE_NAME,
+          systemPath: CWD,
+          environment,
+          correlationId: req.id || req.correlationId || errorInfo.reqId || errorInfo.correlationId || "",
+          userName: Username,
+          method: req.method || "",
+          url: req.url || "",
+          referrer: req.referrer || "",
+          remoteHost: req.remoteAddress || "",
+          userAgent: req.userAgent || "",
+          requestParams: req.params || {},
+          requestBody: req.body || {},
+          requestHeaders: req.headers || {},
+          queryString: req.query || {},
+          exception: errorInfo,
+        };
+
+        let contentType;
+        let body;
+
+        if (format === "json") {
+          contentType = "application/json";
+          body = JSON.stringify(payload);
+        } else {
+          contentType = "application/x-www-form-urlencoded";
+          body = toURLSearchParams(payload).toString();
+        }
 
         if (h2Session && !h2Session.closed && !h2Session.destroyed) {
           // HTTP/2: header names must be lowercase; :method and :path are pseudo-headers
           const headers = {
             ":method": method,
             ":path": `${baseURL.pathname}${baseURL.search}`,
-            "content-type": "application/x-www-form-urlencoded"
+            "content-type": contentType,
+            ...Object.fromEntries(Object.entries(extraHeaders).map(([key, value]) => [key.toLowerCase(), value])),
           };
 
           await new Promise((resolve, reject) => {
@@ -83,18 +126,23 @@ const createWriteStream = function (options = {}) {
             stream.on("data", () => {});
             stream.on("end", resolve);
             stream.on("error", reject);
-            stream.end(queryParams.toString());
+            stream.end(body);
           });
         } else {
           // Fallback to fetch (HTTP/1.1). Undici provides keep-alive by default.
           const headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
+            "Content-Type": contentType,
+            ...extraHeaders,
           };
-          await fetch(baseURL.toString(), {
-            method,
-            headers,
-            body: queryParams.toString(),
-          });
+          try {
+            await fetch(baseURL.toString(), {
+              method,
+              headers,
+              body,
+            });
+          } catch (err) {
+            console.error("[pino-http-send] Fetch error:", err);
+          }
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "main": "index.js",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Support JSON and URL-encoded serialization formats for exception reporting. Add configuration options for custom log levels, API authentication headers, and environment specification. Standardize payload structure across formats with consistent field names (error, message, stackTrace, severity, etc.) to enable better integration with exception monitoring services.