### PR TITLE
feat(http-send): add OpenObserve provider support for remote logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ The framework uses [Pino](https://getpino.io/) v10+ for high-performance, asynch
 - `provider` (string): Which backend to format/send logs for — `"exceptionHandler"` (default, legacy `ExceptionHandler.ashx`-style form post) or `"openobserve"` ([OpenObserve](https://openobserve.ai/) JSON ingest)
 - `url` (string): Full ingest URL, including org/stream/endpoint suffix for OpenObserve (e.g. `.../api/<org-token>/<stream>/_multi`)
 - `username`, `password` (string): Basic auth credentials — **required** when `provider` is `"openobserve"`
-- `bodyType` (string, `"openobserve"` only): `"ndjson"` (default) sends one raw JSON object per request for OpenObserve's `_multi` endpoint; `"json"` wraps the record in an array for the `_json` endpoint
+- `bodyType` (string, `"openobserve"` only): `"ndjson"` (default) sends newline-delimited JSON (one JSON object per line) for OpenObserve's `_multi` endpoint; `"json"` wraps records in a JSON array for the `_json` endpoint
 - `app`, `environment`, `appVersion` (string, `"openobserve"` only): static tags stamped onto every record (e.g. `app: "playbook-backend"`, `environment: "prod"`)
 
 **prettyPrint:**

--- a/README.md
+++ b/README.md
@@ -456,7 +456,14 @@ The framework uses [Pino](https://getpino.io/) v10+ for high-performance, asynch
             "logFolder": "./logs",
             "mixin": null,
             "httpConfig": {
-                "url": "http://xyz.com/error_post",
+                "provider": "openobserve",
+                "url": "https://observe.stream4tech.app/api/<org-token>/<stream>/_multi",
+                "username": "<OBSERVE_USER>",
+                "password": "<OBSERVE_PASSWORD>",
+                "bodyType": "ndjson",
+                "app": "playbook-backend",
+                "environment": "prod",
+                "appVersion": "1.0.11",
                 "headers": {}
             },
             "postLevel": "error"
@@ -491,6 +498,13 @@ The framework uses [Pino](https://getpino.io/) v10+ for high-performance, asynch
 - `mixin` (function): Function to add custom properties to all log entries
 - `httpConfig` (object): HTTP endpoint configuration for remote logging
 - `postLevel` (string): Minimum level for HTTP transport (default: 'error')
+
+**httpConfig (remote logging providers):**
+- `provider` (string): Which backend to format/send logs for — `"exceptionHandler"` (default, legacy `ExceptionHandler.ashx`-style form post) or `"openobserve"` ([OpenObserve](https://openobserve.ai/) JSON ingest)
+- `url` (string): Full ingest URL, including org/stream/endpoint suffix for OpenObserve (e.g. `.../api/<org-token>/<stream>/_multi`)
+- `username`, `password` (string): Basic auth credentials — **required** when `provider` is `"openobserve"`
+- `bodyType` (string, `"openobserve"` only): `"ndjson"` (default) sends one raw JSON object per request for OpenObserve's `_multi` endpoint; `"json"` wraps the record in an array for the `_json` endpoint
+- `app`, `environment`, `appVersion` (string, `"openobserve"` only): static tags stamped onto every record (e.g. `app: "playbook-backend"`, `environment: "prod"`)
 
 **prettyPrint:**
 - `translateTime` (string): Time format for console output

--- a/docs/LOGGER_MIGRATION.md
+++ b/docs/LOGGER_MIGRATION.md
@@ -68,8 +68,8 @@ This document describes the changes made to modernize the logging system from `f
 
 ### Reliability
 - **Graceful shutdown**: Logs are flushed on process exit
-- **Disconnect handling**: Worker threads handle network/disk issues
-- **Built-in retry**: pino-roll handles transient failures
+- **Explicit HTTP failures**: Remote transport now surfaces non-2xx responses instead of silently ignoring them
+- **Batching support**: OpenObserve transport can batch records to reduce per-request overhead under heavy logging
 
 ### Maintainability
 - **Modern API**: Uses pino v10+ best practices

--- a/lib/pino-http-send-providers/exception-handler.mjs
+++ b/lib/pino-http-send-providers/exception-handler.mjs
@@ -1,0 +1,31 @@
+import { MACHINE_NAME, CWD, convertToURLSearchParams, extractCommonFields } from "./shared.mjs";
+
+// Legacy provider: posts form-urlencoded params to an ExceptionHandler-style endpoint
+const NAME = "exceptionHandler";
+
+const validateOptions = () => {};
+
+const buildRequest = (log) => {
+  const { req, Username, time, hostname, rest: errorInfo } = extractCommonFields(log);
+  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
+
+  const queryParams = new URLSearchParams();
+  queryParams.set("Machine Name", hostname || MACHINE_NAME);
+  queryParams.set("System Path", CWD);
+  queryParams.set("Remote Host", req.remoteAddress || "");
+  queryParams.set("User Agent", req.userAgent || "");
+  queryParams.set("Absolute Url", req.url || "");
+  queryParams.set("UrlReferrer", req.referrer || "");
+  queryParams.set("Date/ Time (UTC)", time);
+  queryParams.set("User", Username);
+  queryParams.set("exception", JSON.stringify(errorInfo));
+  queryParams.set("Form", convertToURLSearchParams(paramsObj));
+  queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
+
+  return {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: queryParams.toString(),
+  };
+};
+
+export { NAME, validateOptions, buildRequest };

--- a/lib/pino-http-send-providers/openobserve.mjs
+++ b/lib/pino-http-send-providers/openobserve.mjs
@@ -24,7 +24,7 @@ const buildRequest = (log, options) => {
     environment: environment || "",
     app_version: appVersion || "",
     message: message || msg || (err && err.message) || "",
-    stack_trace: (err && { stack: err.stack, query: extra.query || "" }) || JSON.stringify(extra),
+    stack_trace: JSON.stringify(err ? { stack: err.stack, query: extra.query || "" } : extra),
     machine_name: hostname || MACHINE_NAME,
     date_time: time,
     user: Username,

--- a/lib/pino-http-send-providers/openobserve.mjs
+++ b/lib/pino-http-send-providers/openobserve.mjs
@@ -1,0 +1,50 @@
+import { MACHINE_NAME, extractCommonFields } from "./shared.mjs";
+
+// OpenObserve provider: posts a JSON record with Basic auth (see https://observe.stream4tech.app)
+// bodyType controls the wire format, matching how OpenObserve's two ingest endpoints differ:
+// - "ndjson" (default): raw object per request, for the "_multi" endpoint (used by this backend transport)
+// - "json": object wrapped in an array, for the "_json" endpoint (used by browser/mobile clients)
+const NAME = "openobserve";
+
+const validateOptions = (options) => {
+  if (!options.username || !options.password) {
+    throw new Error(`[pino-http-send] The "${NAME}" provider requires "username" and "password" options`);
+  }
+};
+
+const buildRequest = (log, options) => {
+  const { req, Username, time, hostname, level, rest } = extractCommonFields(log);
+  const { msg, message, err, ...extra } = rest;
+  const { username, password, app, environment, appVersion, bodyType = "ndjson" } = options;
+  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
+
+  const record = {
+    level: level !== undefined ? String(level) : "error",
+    app: app || "",
+    environment: environment || "",
+    app_version: appVersion || "",
+    message: message || msg || (err && err.message) || "",
+    stack_trace: (err && { stack: err.stack, query: extra.query || "" }) || JSON.stringify(extra),
+    machine_name: hostname || MACHINE_NAME,
+    date_time: time,
+    user: Username,
+    ip: req.remoteAddress || "",
+    raw_url: req.url || "",
+    absolute_url: req.url || "",
+    url_referrer: req.referrer || "",
+    query_string: JSON.stringify(req.query || {}),
+    parameters: JSON.stringify(paramsObj),
+    user_agent: req.userAgent || "",
+    browser: req.userAgent || "",
+  };
+
+  return {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
+    },
+    body: bodyType === "json" ? JSON.stringify([record]) : JSON.stringify(record),
+  };
+};
+
+export { NAME, validateOptions, buildRequest };

--- a/lib/pino-http-send-providers/openobserve.mjs
+++ b/lib/pino-http-send-providers/openobserve.mjs
@@ -5,24 +5,50 @@ import { MACHINE_NAME, extractCommonFields } from "./shared.mjs";
 // - "ndjson" (default): raw object per request, for the "_multi" endpoint (used by this backend transport)
 // - "json": object wrapped in an array, for the "_json" endpoint (used by browser/mobile clients)
 const NAME = "openobserve";
+const DEFAULT_BODY_TYPE = "ndjson";
+const SUPPORTED_BODY_TYPES = new Set(["ndjson", "json"]);
 
 const validateOptions = (options) => {
   if (!options.username || !options.password) {
     throw new Error(`[pino-http-send] The "${NAME}" provider requires "username" and "password" options`);
   }
+  if (options.bodyType && !SUPPORTED_BODY_TYPES.has(options.bodyType)) {
+    throw new Error(`[pino-http-send] The "${NAME}" provider only supports bodyType values: ${Array.from(SUPPORTED_BODY_TYPES).join(", ")}`);
+  }
 };
 
-const buildRequest = (log, options) => {
+const createRequestContext = (options) => {
+  const {
+    username,
+    password,
+    app = "",
+    environment = "",
+    appVersion = "",
+    bodyType = DEFAULT_BODY_TYPE,
+  } = options;
+
+  return {
+    app,
+    environment,
+    appVersion,
+    bodyType,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
+    },
+  };
+};
+
+const buildRecord = (log, context) => {
   const { req, Username, time, hostname, level, rest } = extractCommonFields(log);
   const { msg, message, err, ...extra } = rest;
-  const { username, password, app, environment, appVersion, bodyType = "ndjson" } = options;
   const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
 
-  const record = {
+  return {
     level: level !== undefined ? String(level) : "error",
-    app: app || "",
-    environment: environment || "",
-    app_version: appVersion || "",
+    app: context.app,
+    environment: context.environment,
+    app_version: context.appVersion,
     message: message || msg || (err && err.message) || "",
     stack_trace: (err && { stack: err.stack, query: extra.query || "" }) || JSON.stringify(extra),
     machine_name: hostname || MACHINE_NAME,
@@ -37,14 +63,27 @@ const buildRequest = (log, options) => {
     user_agent: req.userAgent || "",
     browser: req.userAgent || "",
   };
+};
+
+const buildRequest = (log, options, requestContext = createRequestContext(options)) => {
+  const record = buildRecord(log, requestContext);
 
   return {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
-    },
-    body: bodyType === "json" ? JSON.stringify([record]) : JSON.stringify(record),
+    headers: requestContext.headers,
+    body: requestContext.bodyType === "json" ? JSON.stringify([record]) : JSON.stringify(record),
   };
 };
 
-export { NAME, validateOptions, buildRequest };
+const buildBatchRequest = (logs, options, requestContext = createRequestContext(options)) => {
+  const records = logs.map((log) => buildRecord(log, requestContext));
+  const body = requestContext.bodyType === "json"
+    ? JSON.stringify(records)
+    : records.map((record) => JSON.stringify(record)).join("\n");
+
+  return {
+    headers: requestContext.headers,
+    body,
+  };
+};
+
+export { NAME, DEFAULT_BODY_TYPE, validateOptions, createRequestContext, buildRecord, buildRequest, buildBatchRequest };

--- a/lib/pino-http-send-providers/openobserve.mjs
+++ b/lib/pino-http-send-providers/openobserve.mjs
@@ -45,7 +45,7 @@ const buildRecord = (log, context) => {
   const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
 
   return {
-    level: level !== undefined ? String(level) : "error",
+    level: level ?? 50, // 50 = pino "error" level, used when the log has no level field
     app: context.app,
     environment: context.environment,
     app_version: context.appVersion,

--- a/lib/pino-http-send-providers/openobserve.mjs
+++ b/lib/pino-http-send-providers/openobserve.mjs
@@ -1,9 +1,9 @@
 import { MACHINE_NAME, extractCommonFields } from "./shared.mjs";
 
-// OpenObserve provider: posts a JSON record with Basic auth (see https://observe.stream4tech.app)
+// OpenObserve provider: posts JSON records with Basic auth (see https://observe.stream4tech.app)
 // bodyType controls the wire format, matching how OpenObserve's two ingest endpoints differ:
-// - "ndjson" (default): raw object per request, for the "_multi" endpoint (used by this backend transport)
-// - "json": object wrapped in an array, for the "_json" endpoint (used by browser/mobile clients)
+// - "ndjson" (default): newline-delimited JSON (one JSON object per line), for the "_multi" endpoint
+// - "json": records wrapped in a JSON array, for the "_json" endpoint
 const NAME = "openobserve";
 const DEFAULT_BODY_TYPE = "ndjson";
 const SUPPORTED_BODY_TYPES = new Set(["ndjson", "json"]);

--- a/lib/pino-http-send-providers/shared.mjs
+++ b/lib/pino-http-send-providers/shared.mjs
@@ -1,0 +1,23 @@
+import os from "os";
+
+// Constants computed once
+export const MACHINE_NAME = os.hostname();
+export const CWD = process.cwd();
+
+// Convert nested objects into URLSearchParams-friendly strings
+export const convertToURLSearchParams = (obj) => {
+  const params = new URLSearchParams();
+  Object.entries(obj || {}).forEach(([key, value]) => {
+    typeof value === "object" && value !== null
+      ? params.append(key, JSON.stringify(value))
+      : params.append(key, value ?? "");
+  });
+  return params.toString();
+};
+
+// Pulls the fields every provider needs out of a parsed pino log line
+export const extractCommonFields = (log) => {
+  const { req = {}, ...others } = log;
+  const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...rest } = others;
+  return { req, Username, time, hostname, pid, level, rest };
+};

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -1,101 +1,18 @@
 import build from "pino-abstract-transport";
-import os from "os";
 import http2 from "node:http2";
+import * as exceptionHandlerProvider from "./pino-http-send-providers/exception-handler.mjs";
+import * as openObserveProvider from "./pino-http-send-providers/openobserve.mjs";
 
-// Constants computed once
-const MACHINE_NAME = os.hostname();
-const CWD = process.cwd();
 const H2_SESSION_CLOSE_TIMEOUT_MS = 300;
 
 const PROVIDERS = {
-  EXCEPTION_HANDLER: "exceptionHandler",
-  OPENOBSERVE: "openobserve",
+  EXCEPTION_HANDLER: exceptionHandlerProvider.NAME,
+  OPENOBSERVE: openObserveProvider.NAME,
 };
 
-// Convert nested objects into URLSearchParams-friendly strings
-const convertToURLSearchParams = (obj) => {
-  const params = new URLSearchParams();
-  Object.entries(obj || {}).forEach(([key, value]) => {
-    typeof value === "object" && value !== null
-      ? params.append(key, JSON.stringify(value))
-      : params.append(key, value ?? "");
-  });
-  return params.toString();
-};
-
-// Pulls the fields every provider needs out of a parsed pino log line
-const extractCommonFields = (log) => {
-  const { req = {}, ...others } = log;
-  const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...rest } = others;
-  return { req, Username, time, hostname, pid, level, rest };
-};
-
-// Legacy provider: posts form-urlencoded params to an ExceptionHandler-style endpoint
-const buildExceptionHandlerRequest = (log) => {
-  const { req, Username, time, hostname, rest: errorInfo } = extractCommonFields(log);
-  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
-
-  const queryParams = new URLSearchParams();
-  queryParams.set("Machine Name", hostname || MACHINE_NAME);
-  queryParams.set("System Path", CWD);
-  queryParams.set("Remote Host", req.remoteAddress || "");
-  queryParams.set("User Agent", req.userAgent || "");
-  queryParams.set("Absolute Url", req.url || "");
-  queryParams.set("UrlReferrer", req.referrer || "");
-  queryParams.set("Date/ Time (UTC)", time);
-  queryParams.set("User", Username);
-  queryParams.set("exception", JSON.stringify(errorInfo));
-  queryParams.set("Form", convertToURLSearchParams(paramsObj));
-  queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
-
-  return {
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: queryParams.toString(),
-  };
-};
-
-// OpenObserve provider: posts a JSON record with Basic auth (see https://observe.stream4tech.app)
-// bodyType controls the wire format, matching how OpenObserve's two ingest endpoints differ:
-// - "ndjson" (default): raw object per request, for the "_multi" endpoint (used by this backend transport)
-// - "json": object wrapped in an array, for the "_json" endpoint (used by browser/mobile clients)
-const buildOpenObserveRequest = (log, options) => {
-  const { req, Username, time, hostname, level, rest } = extractCommonFields(log);
-  const { msg, message, err, ...extra } = rest;
-  const { username, password, app, environment, appVersion, bodyType = "json" } = options;
-  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
-
-  const record = {
-    level: level !== undefined ? String(level) : "error",
-    app: app || "",
-    environment: environment || "",
-    app_version: appVersion || "",
-    message: message || msg || (err && err.message) || "",
-    stack_trace: (err && err.stack) || JSON.stringify(extra),
-    machine_name: hostname || MACHINE_NAME,
-    date_time: time,
-    user: Username,
-    ip: req.remoteAddress || "",
-    raw_url: req.url || "",
-    absolute_url: req.url || "",
-    url_referrer: req.referrer || "",
-    query_string: JSON.stringify(req.query || {}),
-    parameters: JSON.stringify(paramsObj),
-    user_agent: req.userAgent || "",
-    browser: req.userAgent || "",
-  };
-
-  return {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
-    },
-    body: bodyType === "json" ? JSON.stringify([record]) : JSON.stringify(record),
-  };
-};
-
-const REQUEST_BUILDERS = {
-  [PROVIDERS.EXCEPTION_HANDLER]: buildExceptionHandlerRequest,
-  [PROVIDERS.OPENOBSERVE]: buildOpenObserveRequest,
+const PROVIDER_MODULES = {
+  [exceptionHandlerProvider.NAME]: exceptionHandlerProvider,
+  [openObserveProvider.NAME]: openObserveProvider,
 };
 
 /**
@@ -116,15 +33,13 @@ const createWriteStream = function (options = {}) {
   const baseURL = new URL(options.url);
   const useHttp2 = options.http2 === true && baseURL.protocol === "https:";
   const method = (options.method || "POST").toUpperCase();
-  const provider = options.provider || PROVIDERS.EXCEPTION_HANDLER;
+  const providerName = options.provider || PROVIDERS.EXCEPTION_HANDLER;
 
-  const buildRequest = REQUEST_BUILDERS[provider];
-  if (!buildRequest) {
-    throw new Error(`[pino-http-send] Unknown provider "${provider}". Expected one of: ${Object.values(PROVIDERS).join(", ")}`);
+  const provider = PROVIDER_MODULES[providerName];
+  if (!provider) {
+    throw new Error(`[pino-http-send] Unknown provider "${providerName}". Expected one of: ${Object.values(PROVIDERS).join(", ")}`);
   }
-  if (provider === PROVIDERS.OPENOBSERVE && (!options.username || !options.password)) {
-    throw new Error('[pino-http-send] The "openobserve" provider requires "username" and "password" options');
-  }
+  provider.validateOptions(options);
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)
   let h2Session = null;
@@ -146,7 +61,7 @@ const createWriteStream = function (options = {}) {
           continue;
         }
 
-        const { headers, body } = buildRequest(log, options);
+        const { headers, body } = provider.buildRequest(log, options);
 
         if (h2Session && !h2Session.closed && !h2Session.destroyed) {
           // HTTP/2: header names must be lowercase; :method and :path are pseudo-headers

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -97,11 +97,17 @@ const createWriteStream = function (options = {}) {
       return;
     }
 
-    const buildRequest = logs.length > 1 && typeof provider.buildBatchRequest === "function"
-      ? provider.buildBatchRequest.bind(provider)
-      : provider.buildRequest.bind(provider);
-    const { headers, body } = buildRequest(logs.length > 1 && typeof provider.buildBatchRequest === "function" ? logs : logs[0], options, providerRequestContext);
-    await sendRequest({ ...(options.headers || {}), ...headers }, body);
+    if (logs.length > 1 && typeof provider.buildBatchRequest === "function") {
+      const { headers, body } = provider.buildBatchRequest(logs, options, providerRequestContext);
+      await sendRequest({ ...(options.headers || {}), ...headers }, body);
+      return;
+    }
+
+    // No batch support (or a single log): send every log individually so none are dropped.
+    for (const log of logs) {
+      const { headers, body } = provider.buildRequest(log, options, providerRequestContext);
+      await sendRequest({ ...(options.headers || {}), ...headers }, body);
+    }
   };
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -7,6 +7,11 @@ const MACHINE_NAME = os.hostname();
 const CWD = process.cwd();
 const H2_SESSION_CLOSE_TIMEOUT_MS = 300;
 
+const PROVIDERS = {
+  EXCEPTION_HANDLER: "exceptionHandler",
+  OPENOBSERVE: "openobserve",
+};
+
 // Convert nested objects into URLSearchParams-friendly strings
 const convertToURLSearchParams = (obj) => {
   const params = new URLSearchParams();
@@ -18,10 +23,92 @@ const convertToURLSearchParams = (obj) => {
   return params.toString();
 };
 
+// Pulls the fields every provider needs out of a parsed pino log line
+const extractCommonFields = (log) => {
+  const { req = {}, ...others } = log;
+  const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...rest } = others;
+  return { req, Username, time, hostname, pid, level, rest };
+};
+
+// Legacy provider: posts form-urlencoded params to an ExceptionHandler-style endpoint
+const buildExceptionHandlerRequest = (log) => {
+  const { req, Username, time, hostname, rest: errorInfo } = extractCommonFields(log);
+  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
+
+  const queryParams = new URLSearchParams();
+  queryParams.set("Machine Name", hostname || MACHINE_NAME);
+  queryParams.set("System Path", CWD);
+  queryParams.set("Remote Host", req.remoteAddress || "");
+  queryParams.set("User Agent", req.userAgent || "");
+  queryParams.set("Absolute Url", req.url || "");
+  queryParams.set("UrlReferrer", req.referrer || "");
+  queryParams.set("Date/ Time (UTC)", time);
+  queryParams.set("User", Username);
+  queryParams.set("exception", JSON.stringify(errorInfo));
+  queryParams.set("Form", convertToURLSearchParams(paramsObj));
+  queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
+
+  return {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: queryParams.toString(),
+  };
+};
+
+// OpenObserve provider: posts a JSON record with Basic auth (see https://observe.stream4tech.app)
+// bodyType controls the wire format, matching how OpenObserve's two ingest endpoints differ:
+// - "ndjson" (default): raw object per request, for the "_multi" endpoint (used by this backend transport)
+// - "json": object wrapped in an array, for the "_json" endpoint (used by browser/mobile clients)
+const buildOpenObserveRequest = (log, options) => {
+  const { req, Username, time, hostname, level, rest } = extractCommonFields(log);
+  const { msg, message, err, ...extra } = rest;
+  const { username, password, app, environment, appVersion, bodyType = "json" } = options;
+  const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
+
+  const record = {
+    level: level !== undefined ? String(level) : "error",
+    app: app || "",
+    environment: environment || "",
+    app_version: appVersion || "",
+    message: message || msg || (err && err.message) || "",
+    stack_trace: (err && err.stack) || JSON.stringify(extra),
+    machine_name: hostname || MACHINE_NAME,
+    date_time: time,
+    user: Username,
+    ip: req.remoteAddress || "",
+    raw_url: req.url || "",
+    absolute_url: req.url || "",
+    url_referrer: req.referrer || "",
+    query_string: JSON.stringify(req.query || {}),
+    parameters: JSON.stringify(paramsObj),
+    user_agent: req.userAgent || "",
+    browser: req.userAgent || "",
+  };
+
+  return {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${username}:${password}`).toString("base64"),
+    },
+    body: bodyType === "json" ? JSON.stringify([record]) : JSON.stringify(record),
+  };
+};
+
+const REQUEST_BUILDERS = {
+  [PROVIDERS.EXCEPTION_HANDLER]: buildExceptionHandlerRequest,
+  [PROVIDERS.OPENOBSERVE]: buildOpenObserveRequest,
+};
+
 /**
  * Creates a write stream for pino transport that POSTs each log line.
  * Options:
  * - url: string (required) Target endpoint
+ * - provider: string (optional) Which backend to format/send for; one of
+ *     "exceptionHandler" (default, legacy ExceptionHandler.ashx-style form post) or
+ *     "openobserve" (JSON record with Basic auth, e.g. observe.stream4tech.app)
+ * - username, password: string (required when provider is "openobserve") Basic auth credentials
+ * - bodyType: string (optional, "openobserve" only) "ndjson" (default, "_multi" endpoint) or
+ *     "json" (array-wrapped, "_json" endpoint)
+ * - app, environment, appVersion: string (optional, "openobserve" only) static tags added to every record
  * - http2: boolean (optional) If true and endpoint is https, use HTTP/2 client
  * - method: string (optional) HTTP method; defaults to "POST"
  */
@@ -29,6 +116,15 @@ const createWriteStream = function (options = {}) {
   const baseURL = new URL(options.url);
   const useHttp2 = options.http2 === true && baseURL.protocol === "https:";
   const method = (options.method || "POST").toUpperCase();
+  const provider = options.provider || PROVIDERS.EXCEPTION_HANDLER;
+
+  const buildRequest = REQUEST_BUILDERS[provider];
+  if (!buildRequest) {
+    throw new Error(`[pino-http-send] Unknown provider "${provider}". Expected one of: ${Object.values(PROVIDERS).join(", ")}`);
+  }
+  if (provider === PROVIDERS.OPENOBSERVE && (!options.username || !options.password)) {
+    throw new Error('[pino-http-send] The "openobserve" provider requires "username" and "password" options');
+  }
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)
   let h2Session = null;
@@ -50,50 +146,33 @@ const createWriteStream = function (options = {}) {
           continue;
         }
 
-        const { req = {}, ...others } = log;
-        const { Username = "", time = new Date().toISOString(), hostname, pid, level, ...errorInfo } = others;
-        const paramsObj = { ...(req.params || {}), ...(req.body || {}) };
-
-        // Build query params per line
-        const queryParams = new URLSearchParams();
-        queryParams.set("Machine Name", hostname || MACHINE_NAME);
-        queryParams.set("System Path", CWD);
-        queryParams.set("Remote Host", req.remoteAddress || "");
-        queryParams.set("User Agent", req.userAgent || "");
-        queryParams.set("Absolute Url", req.url || "");
-        queryParams.set("UrlReferrer", req.referrer || "");
-        queryParams.set("Date/ Time (UTC)", time);
-        queryParams.set("User", Username);
-        queryParams.set("exception", JSON.stringify(errorInfo));
-        queryParams.set("Form", convertToURLSearchParams(paramsObj));
-        queryParams.set("QueryString", convertToURLSearchParams(req.query || {}));
+        const { headers, body } = buildRequest(log, options);
 
         if (h2Session && !h2Session.closed && !h2Session.destroyed) {
           // HTTP/2: header names must be lowercase; :method and :path are pseudo-headers
-          const headers = {
+          const h2Headers = {
             ":method": method,
             ":path": `${baseURL.pathname}${baseURL.search}`,
-            "content-type": "application/x-www-form-urlencoded"
           };
+          Object.entries(headers).forEach(([key, value]) => {
+            h2Headers[key.toLowerCase()] = value;
+          });
 
           await new Promise((resolve, reject) => {
-            const stream = h2Session.request(headers);
+            const stream = h2Session.request(h2Headers);
             // Consume response to free stream resources
             stream.on("response", () => {});
             stream.on("data", () => {});
             stream.on("end", resolve);
             stream.on("error", reject);
-            stream.end(queryParams.toString());
+            stream.end(body);
           });
         } else {
           // Fallback to fetch (HTTP/1.1). Undici provides keep-alive by default.
-          const headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-          };
           await fetch(baseURL.toString(), {
             method,
             headers,
-            body: queryParams.toString(),
+            body,
           });
         }
       }
@@ -120,4 +199,4 @@ const createWriteStream = function (options = {}) {
 };
 
 export default createWriteStream;
-export { createWriteStream };
+export { createWriteStream, PROVIDERS };

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -25,6 +25,7 @@ const PROVIDER_MODULES = {
  * - username, password: string (required when provider is "openobserve") Basic auth credentials
  * - bodyType: string (optional, "openobserve" only) "ndjson" (default, "_multi" endpoint) or
  *     "json" (array-wrapped, "_json" endpoint)
+ * - batchSize: number (optional, "openobserve" only) Number of parsed log records to send per request; defaults to 1
  * - app, environment, appVersion: string (optional, "openobserve" only) static tags added to every record
  * - http2: boolean (optional) If true and endpoint is https, use HTTP/2 client
  * - method: string (optional) HTTP method; defaults to "POST"
@@ -34,12 +35,74 @@ const createWriteStream = function (options = {}) {
   const useHttp2 = options.http2 === true && baseURL.protocol === "https:";
   const method = (options.method || "POST").toUpperCase();
   const providerName = options.provider || PROVIDERS.EXCEPTION_HANDLER;
+  const batchSize = Math.max(1, Number(options.batchSize) || 1);
 
   const provider = PROVIDER_MODULES[providerName];
   if (!provider) {
     throw new Error(`[pino-http-send] Unknown provider "${providerName}". Expected one of: ${Object.values(PROVIDERS).join(", ")}`);
   }
   provider.validateOptions(options);
+  const providerRequestContext = provider.createRequestContext?.(options);
+
+  const sendRequest = async (headers, body) => {
+    if (h2Session && !h2Session.closed && !h2Session.destroyed) {
+      const h2Headers = {
+        ":method": method,
+        ":path": `${baseURL.pathname}${baseURL.search}`,
+      };
+      Object.entries(headers).forEach(([key, value]) => {
+        h2Headers[key.toLowerCase()] = value;
+      });
+
+      await new Promise((resolve, reject) => {
+        const stream = h2Session.request(h2Headers);
+        let statusCode = 0;
+        let responseBody = "";
+
+        stream.setEncoding("utf8");
+        stream.on("response", (responseHeaders) => {
+          statusCode = Number(responseHeaders[http2.constants.HTTP2_HEADER_STATUS] || 0);
+        });
+        stream.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        stream.on("end", () => {
+          if (statusCode >= 200 && statusCode < 300) {
+            resolve();
+            return;
+          }
+          reject(new Error(`[pino-http-send] Request failed with status ${statusCode}${responseBody ? `: ${responseBody}` : ""}`));
+        });
+        stream.on("error", reject);
+        stream.end(body);
+      });
+
+      return;
+    }
+
+    const response = await fetch(baseURL.toString(), {
+      method,
+      headers,
+      body,
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => "");
+      throw new Error(`[pino-http-send] Request failed with status ${response.status}${responseBody ? `: ${responseBody}` : ""}`);
+    }
+  };
+
+  const flushBatch = async (logs) => {
+    if (logs.length === 0) {
+      return;
+    }
+
+    const buildRequest = logs.length > 1 && typeof provider.buildBatchRequest === "function"
+      ? provider.buildBatchRequest.bind(provider)
+      : provider.buildRequest.bind(provider);
+    const { headers, body } = buildRequest(logs.length > 1 ? logs : logs[0], options, providerRequestContext);
+    await sendRequest(headers, body);
+  };
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)
   let h2Session = null;
@@ -52,6 +115,8 @@ const createWriteStream = function (options = {}) {
 
   return build(
     async (source) => {
+      const pendingLogs = [];
+
       for await (const line of source) {
         let log;
         try {
@@ -61,37 +126,13 @@ const createWriteStream = function (options = {}) {
           continue;
         }
 
-        const { headers, body } = provider.buildRequest(log, options);
-
-        if (h2Session && !h2Session.closed && !h2Session.destroyed) {
-          // HTTP/2: header names must be lowercase; :method and :path are pseudo-headers
-          const h2Headers = {
-            ":method": method,
-            ":path": `${baseURL.pathname}${baseURL.search}`,
-          };
-          Object.entries(headers).forEach(([key, value]) => {
-            h2Headers[key.toLowerCase()] = value;
-          });
-
-          await new Promise((resolve, reject) => {
-            const stream = h2Session.request(h2Headers);
-            // Consume response to free stream resources
-            stream.on("response", () => {});
-            stream.on("data", () => {});
-            stream.on("end", resolve);
-            stream.on("error", reject);
-            stream.end(body);
-          });
-        } else {
-          // Fallback to fetch (HTTP/1.1). Undici provides keep-alive by default.
-          await fetch(baseURL.toString(), {
-            method,
-            headers,
-            body,
-          });
+        pendingLogs.push(log);
+        if (pendingLogs.length >= batchSize) {
+          await flushBatch(pendingLogs.splice(0, pendingLogs.length));
         }
       }
 
+      await flushBatch(pendingLogs);
       return source;
     },
     {

--- a/lib/pino-http-send.mjs
+++ b/lib/pino-http-send.mjs
@@ -100,8 +100,8 @@ const createWriteStream = function (options = {}) {
     const buildRequest = logs.length > 1 && typeof provider.buildBatchRequest === "function"
       ? provider.buildBatchRequest.bind(provider)
       : provider.buildRequest.bind(provider);
-    const { headers, body } = buildRequest(logs.length > 1 ? logs : logs[0], options, providerRequestContext);
-    await sendRequest(headers, body);
+    const { headers, body } = buildRequest(logs.length > 1 && typeof provider.buildBatchRequest === "function" ? logs : logs[0], options, providerRequestContext);
+    await sendRequest({ ...(options.headers || {}), ...headers }, body);
   };
 
   // Prepare HTTP/2 session if enabled (synchronously creates a client session)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "main": "index.js",
   "license": "MIT",
   "type": "module",

--- a/tests/pino-http-send-flush.test.mjs
+++ b/tests/pino-http-send-flush.test.mjs
@@ -51,9 +51,11 @@ const sampleLog = (msg) => ({
     batchSize: 3,
   });
 
-  await writeLinesAndClose(stream, [sampleLog('first'), sampleLog('second'), sampleLog('third')]);
-
-  globalThis.fetch = originalFetch;
+  try {
+    await writeLinesAndClose(stream, [sampleLog('first'), sampleLog('second'), sampleLog('third')]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 
   test('no buildBatchRequest: sends one request per buffered log (no data loss)', calls.length === 3);
   test('no buildBatchRequest: preserves each log body distinctly', calls.every((body, i) => body.includes(['first', 'second', 'third'][i])));

--- a/tests/pino-http-send-flush.test.mjs
+++ b/tests/pino-http-send-flush.test.mjs
@@ -1,0 +1,67 @@
+import { createWriteStream } from '../lib/pino-http-send.mjs';
+
+let passCount = 0;
+let failCount = 0;
+
+const test = (name, condition) => {
+  if (condition) {
+    console.log(`✓ ${name}`);
+    passCount++;
+  } else {
+    console.log(`✗ ${name}`);
+    failCount++;
+  }
+};
+
+const writeLinesAndClose = (stream, lines) => new Promise((resolve, reject) => {
+  stream.on('error', reject);
+  stream.on('close', resolve);
+  for (const line of lines) {
+    stream.write(`${JSON.stringify(line)}\n`);
+  }
+  stream.end();
+});
+
+const sampleLog = (msg) => ({
+  level: 50,
+  time: '2026-08-04T00:00:00.000Z',
+  Username: 'copilot',
+  msg,
+  req: {
+    url: '/users',
+    query: {},
+    params: {},
+    body: {},
+  },
+});
+
+// exceptionHandler provider has no buildBatchRequest — with batchSize > 1, flushBatch
+// must still send every buffered log individually instead of dropping all but the first.
+{
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push(init.body);
+    return { ok: true, text: async () => '' };
+  };
+
+  const stream = createWriteStream({
+    url: 'http://example.com/ExceptionHandler.ashx',
+    provider: 'exceptionHandler',
+    batchSize: 3,
+  });
+
+  await writeLinesAndClose(stream, [sampleLog('first'), sampleLog('second'), sampleLog('third')]);
+
+  globalThis.fetch = originalFetch;
+
+  test('no buildBatchRequest: sends one request per buffered log (no data loss)', calls.length === 3);
+  test('no buildBatchRequest: preserves each log body distinctly', calls.every((body, i) => body.includes(['first', 'second', 'third'][i])));
+}
+
+console.log(`Passed: ${passCount}`);
+console.log(`Failed: ${failCount}`);
+
+if (failCount > 0) {
+  process.exit(1);
+}

--- a/tests/pino-http-send.test.mjs
+++ b/tests/pino-http-send.test.mjs
@@ -1,0 +1,80 @@
+import {
+  DEFAULT_BODY_TYPE,
+  buildBatchRequest,
+  buildRequest,
+  createRequestContext,
+  validateOptions,
+} from '../lib/pino-http-send-providers/openobserve.mjs';
+
+let passCount = 0;
+let failCount = 0;
+
+const test = (name, condition) => {
+  if (condition) {
+    console.log(`✓ ${name}`);
+    passCount++;
+  } else {
+    console.log(`✗ ${name}`);
+    failCount++;
+  }
+};
+
+const throws = (fn, pattern) => {
+  try {
+    fn();
+    return false;
+  } catch (error) {
+    return pattern.test(error.message);
+  }
+};
+
+const options = {
+  username: 'user',
+  password: 'pass',
+  app: 'dframework',
+  environment: 'test',
+  appVersion: '1.2.3',
+};
+
+const sampleLog = {
+  level: 50,
+  time: '2026-08-04T00:00:00.000Z',
+  Username: 'copilot',
+  msg: 'boom',
+  req: {
+    url: '/users',
+    query: { page: 1 },
+    params: { id: 5 },
+    body: { filter: 'active' },
+    remoteAddress: '127.0.0.1',
+    userAgent: 'test-agent',
+  },
+};
+
+validateOptions(options);
+test('default body type constant is ndjson', DEFAULT_BODY_TYPE === 'ndjson');
+test('invalid body type is rejected', throws(() => validateOptions({ ...options, bodyType: 'xml' }), /bodyType values/));
+
+const context = createRequestContext(options);
+const singleRequest = buildRequest(sampleLog, options, context);
+const singleRecord = JSON.parse(singleRequest.body);
+
+test('single request uses basic auth header', singleRequest.headers.Authorization === 'Basic ' + Buffer.from('user:pass').toString('base64'));
+test('single request stamps app metadata', singleRecord.app === 'dframework' && singleRecord.environment === 'test' && singleRecord.app_version === '1.2.3');
+test('single request merges params and body', singleRecord.parameters === JSON.stringify({ id: 5, filter: 'active' }));
+
+const batchRequest = buildBatchRequest([sampleLog, { ...sampleLog, msg: 'again' }], options, context);
+const ndjsonLines = batchRequest.body.split('\n');
+test('batch request emits ndjson lines', ndjsonLines.length === 2);
+test('batch request preserves each record message', JSON.parse(ndjsonLines[1]).message === 'again');
+
+const jsonBatchRequest = buildBatchRequest([sampleLog, { ...sampleLog, msg: 'json' }], { ...options, bodyType: 'json' });
+const jsonBatchBody = JSON.parse(jsonBatchRequest.body);
+test('json body type emits a JSON array', Array.isArray(jsonBatchBody) && jsonBatchBody.length === 2);
+
+console.log(`Passed: ${passCount}`);
+console.log(`Failed: ${failCount}`);
+
+if (failCount > 0) {
+  process.exit(1);
+}

--- a/tests/pino-http-send.test.mjs
+++ b/tests/pino-http-send.test.mjs
@@ -61,7 +61,7 @@ const singleRecord = JSON.parse(singleRequest.body);
 
 test('single request uses basic auth header', singleRequest.headers.Authorization === 'Basic ' + Buffer.from('user:pass').toString('base64'));
 test('single request stamps app metadata', singleRecord.app === 'dframework' && singleRecord.environment === 'test' && singleRecord.app_version === '1.2.3');
-test('single request merges params and body', singleRecord.parameters === JSON.stringify({ id: 5, filter: 'active' }));
+test('single request merges params and body', JSON.stringify(singleRecord.parameters) === JSON.stringify({ id: 5, filter: 'active' }));
 
 const batchRequest = buildBatchRequest([sampleLog, { ...sampleLog, msg: 'again' }], options, context);
 const ndjsonLines = batchRequest.body.split('\n');


### PR DESCRIPTION
The library previously only supported sending logs to legacy ExceptionHandler-style endpoints. This change introduces pluggable provider support, enabling integration with modern observability platforms like OpenObserve while maintaining backward compatibility. Extracted common field extraction into a shared utility and implemented provider-specific builders for both ExceptionHandler (legacy) and OpenObserve formats. OpenObserve support includes configurable JSON wire formats (ndjson for _multi endpoint, json for _json endpoint), HTTP Basic authentication, and static metadata tags (app, environment, appVersion) stamped onto every record. Updated documentation with configuration examples and detailed parameter descriptions.