### PR TITLE
#75708 - add doesNotContain alias

### DIFF
--- a/lib/business/business-base.mjs
+++ b/lib/business/business-base.mjs
@@ -151,6 +151,7 @@ compareLookups.isBefore = compareLookups['<'];
 compareLookups.isAfter = compareLookups['>'];
 compareLookups.isOnOrBefore = compareLookups['<='];
 compareLookups.isOnOrAfter = compareLookups['>='];
+compareLookups.doesNotContain = compareLookups.notContains;
 
 const extendClass = function (baseClass, defaultProperties, config) {
     const ExtendedClass = class extends baseClass {


### PR DESCRIPTION
Create an alias for the notContains comparison lookup to support alternative naming conventions. The doesNotContain alias points to the same functionality as notContains, allowing consumers to use their preferred method name for improved code readability and API consistency.